### PR TITLE
chore: add section on callbackurl for oidc

### DIFF
--- a/authentication/methods.mdx
+++ b/authentication/methods.mdx
@@ -9,7 +9,7 @@ description: This document describes the various supported authentication method
   configure the various authentication methods.
 </Note>
 
-#### Static Token
+## Static Token
 
 <Tip>
   When `token` method is enabled and no static tokens exist in the backing
@@ -21,7 +21,7 @@ The `token` authentication method supports statically creating authentication to
 Once enabled, the `/auth/v1/method/token` API prefix is mounted to Flipt's API.
 This section of the API supports the creation of static tokens.
 
-**Example: Token Creation**
+### Example: Token Creation
 
 The following `curl` command creates a static token with no expiration.
 Given authentication is set to `required` then a prior client token will be required to perform this action.
@@ -33,7 +33,7 @@ curl -X POST localhost:8080/auth/v1/method/token \
     --data '{"name":"access_all_areas","description":"keys to the castle"}'
 ```
 
-#### OpenID Connect
+## OpenID Connect
 
 [OpenID Connect](https://openid.net/connect/) (OIDC) is a simple identity layer on top of the OAuth 2.0 protocol. It allows Clients to verify the identity of the End-User based on the authentication performed by an Authorization Server, as well as to obtain basic profile information about the End-User in an interoperable and REST-like manner.
 

--- a/authentication/overview.mdx
+++ b/authentication/overview.mdx
@@ -31,7 +31,7 @@ For now, we recommened excluding these API prefixes from your load-balancer.
 
 </Warning>
 
-### Client Tokens
+## Client Tokens
 
 Client tokens are the core credential required to authenticate a request.
 Tokens themselves are acquired via [authentication methods](/authentication/methods).
@@ -42,3 +42,10 @@ Flipt currently supports two authentication methods for acquiring credentials:
 2. [OIDC](/authentication/methods/#oidc)
 
 Once a `client token` has been acquired, it can be supplied via request metadata dependent on the protocol. Both HTTP and gRPC examples can be found on the [Using Client Tokens](/authentication/using-tokens) page.
+
+## Authorization
+
+Currently, Flipt only supports authentication without any extended authorization capabilities.
+Authorization is something we're actively exploring and we will update this section as we settle on a design.
+
+We would appreciate your input into designing authorization. Head over to [our discord](https://flipt.io/discord) and let us know what you need from Flipt.

--- a/configuration/authentication.mdx
+++ b/configuration/authentication.mdx
@@ -3,8 +3,6 @@ title: Authentication
 description: This document describes how to configure Flipt's authentication mechanisms.
 ---
 
-## Authentication
-
 <Warning>
 Once authentication has been set to `required: true` all API routes will require a client token to be present.
 
@@ -23,7 +21,7 @@ When authentication is set to `required`, the API will ensure valid credentials 
 
 See the [Authentication: Overview](/authentication/overview) documentation for more details on Flipt's API authentication handling.
 
-### Session
+## Session
 
 This section contains common properties for establishing browser sessions via a "session compatible" authentication method. Session-compatible methods enable support for login in the UI. The methods below state whether or not they are session compatible (e.g. [OIDC](#method-oidc) is session compatible).
 
@@ -54,13 +52,13 @@ openssl rand -base64 64
 
 </Card>
 
-### Methods
+## Methods
 
 Each key within the `methods` section is a particular authentication method.
 These methods are disabled (`enabled: false`) by default.
 Enabling and configuring a method allows for different ways to establish client token credentials within Flipt.
 
-#### Method: Static Token
+### Method: Static Token
 
 The `token` method provides the ability to create client tokens statically, with optional expiry constraints.
 
@@ -76,7 +74,7 @@ Once enabled, static tokens can be created via the [CreateToken](/reference/auth
 
 Further explanation for using this method can be found in the [Authentication: Static Token](/authentication/methods#static-token) documentation.
 
-#### Method: OIDC
+### Method: OIDC
 
 <Note>This is a `session compatible` authentication method.</Note>
 
@@ -111,13 +109,53 @@ Flipt has been tested with each of the following providers:
 - [Auth0](https://auth0.com/docs/get-started/applications/application-settings)
 - [Gitlab](https://docs.gitlab.com/ee/integration/openid_connect_provider.html)
 - [Dex](https://dexidp.io/docs/openid-connect/)
+- [Okta](https://developer.okta.com/docs/concepts/oauth-openid/#oauth-2-0)
 
 Though the intention is that it should work with other OIDC providers, these are just the handful the Flipt team has validated.
 
 Following any of the links above should take you to the relevant documentation for each of these providers' OIDC client setups.
 You can use the credentials and client configuration obtained using those steps as configuration for your Flipt instance.
 
-**Example: OIDC with Google**
+#### Callback URL
+
+When configuring your OIDC provider, you will need to provide a callback URL for the provider to redirect back to Flipt after a successful login.
+
+The callback URL will be in the form of `https://your.flipt.instance.url.com/auth/v1/method/oidc/{provider}/callback`.
+
+You can find the callback URL for each provider that you configure in your Flipt instance by querying the API.
+
+```bash
+curl --request GET \
+  --url https://your.flipt.instance.url.com/auth/v1/method \
+  --header 'Accept: application/json'
+
+
+{
+	"methods": [
+		{
+			"method": "METHOD_TOKEN",
+			"enabled": true,
+			"sessionCompatible": false,
+			"metadata": null
+		},
+		{
+			"method": "METHOD_OIDC",
+			"enabled": true,
+			"sessionCompatible": true,
+			"metadata": {
+				"providers": {
+					"google": {
+						"authorize_url": "/auth/v1/method/oidc/google/authorize",
+						"callback_url": "/auth/v1/method/oidc/google/callback"
+					}
+				}
+			}
+		}
+	]
+}
+```
+
+#### Example: OIDC with Google
 
 Given we're running our instance of Flipt on the public internet at `https://flipt.myorg.com`.
 
@@ -146,11 +184,14 @@ authentication:
             - profile
 ```
 
-<Info>
-  Additional `scopes` such as `profile` are not 100% necessary, however, adding
-  them will result in Flipt being able to identify more details about your users
-  such as personalized greeting messages and user profile pictures in the UI.
-</Info>
+<Note>
+  The callback URL for this provider would be
+  `https://flipt.myorg.com/auth/v1/method/oidc/google/callback`.
+</Note>
+
+Additional `scopes` such as `profile` are not 100% necessary, however, adding
+them will result in Flipt being able to identify more details about your users
+such as personalized greeting messages and user profile pictures in the UI.
 
 Once this configuration has been enabled a `Login with Google` option will be presented in the UI.
 Clicking this button will navigate the user to a Google consent screen.
@@ -163,7 +204,7 @@ Other providers have similar mechanisms for attenuating who can leverage this au
 
 </Tip>
 
-#### Common Properties: Cleanup
+### Common Properties: Cleanup
 
 Each authentication method contains a nested `cleanup` configuration object.
 This object configures the periodic deletion of _expired_ authentications created with the associated method.
@@ -187,14 +228,7 @@ The grace period is added onto this timestamp as a predicate when the delete ope
 Tokens that have expired (`expires_at` is before `now()`) will begin immediately failing authentication when presented as a credential to the API.
 The `grace_period` is simply for the cleanup process.
 
-### Reverse Proxy
+## Reverse Proxy
 
 It is possible to secure Flipt simply by running it behind a reverse proxy in your own trusted environment.
 An example of this can be found in the core Flipt repository [here](https://github.com/flipt-io/flipt/tree/main/examples/auth).
-
-## Authorization
-
-Currently, Flipt only supports authentication without any extended authorization capabilities.
-Authorization is something we're actively exploring and we will update this section as we settle on a design.
-
-We would appreciate your input into designing authorization. Head over to [our discord](https://flipt.io/discord) and let us know what you need from Flipt.

--- a/configuration/authentication.mdx
+++ b/configuration/authentication.mdx
@@ -128,30 +128,31 @@ You can find the callback URL for each provider that you configure in your Flipt
 curl --request GET \
   --url https://your.flipt.instance.url.com/auth/v1/method \
   --header 'Accept: application/json'
+```
 
-
+```json
 {
-	"methods": [
-		{
-			"method": "METHOD_TOKEN",
-			"enabled": true,
-			"sessionCompatible": false,
-			"metadata": null
-		},
-		{
-			"method": "METHOD_OIDC",
-			"enabled": true,
-			"sessionCompatible": true,
-			"metadata": {
-				"providers": {
-					"google": {
-						"authorize_url": "/auth/v1/method/oidc/google/authorize",
-						"callback_url": "/auth/v1/method/oidc/google/callback"
-					}
-				}
-			}
-		}
-	]
+  "methods": [
+    {
+      "method": "METHOD_TOKEN",
+      "enabled": true,
+      "sessionCompatible": false,
+      "metadata": null
+    },
+    {
+      "method": "METHOD_OIDC",
+      "enabled": true,
+      "sessionCompatible": true,
+      "metadata": {
+        "providers": {
+          "google": {
+            "authorize_url": "/auth/v1/method/oidc/google/authorize",
+            "callback_url": "/auth/v1/method/oidc/google/callback"
+          }
+        }
+      }
+    }
+  ]
 }
 ```
 


### PR DESCRIPTION
- added section on getting the `callback_url` for oidc method
- re-organized some headings/levels 
- moved `authorization` to the Authentication: Overview section, since it seemed more fitting there instead of the configuration section

![CleanShot 2023-01-29 at 12 59 34](https://user-images.githubusercontent.com/209477/215346133-e843e914-90b5-4049-93f0-3b262374b3e0.png)
