### PR TITLE
chore: telemetry and links updates in docs

### DIFF
--- a/configuration/authentication.mdx
+++ b/configuration/authentication.mdx
@@ -6,7 +6,7 @@ description: This document describes how to configure Flipt's authentication mec
 <Warning>
 Once authentication has been set to `required: true` all API routes will require a client token to be present.
 
-The UI will require a session-compatible authentication method (e.g. [OIDC](#OIDC)) to be enabled.
+The UI will require a session-compatible authentication method (e.g. [OIDC](#method-oidc)) to be enabled.
 
 </Warning>
 

--- a/configuration/observability.mdx
+++ b/configuration/observability.mdx
@@ -70,12 +70,12 @@ You can find the dashboards in our [grafana-dashboards](https://github.com/flipt
 
 ## Tracing
 
-Flipt supports distributed tracing via the
-[OpenTracing](https://opentracing.io/) protocol and
-[Jaeger](https://www.jaegertracing.io/) library. Enable tracing via the
-configuration values described above and point Flipt to your Jaeger host to
-record spans.
+Flipt supports distributed tracing via the [OpenTelemetry](https://opentelemetry.io/) project.
 
-There is an
-[example](https://github.com/flipt-io/flipt/tree/main/examples/tracing) provided
-in the GitHub repository showing how to set up Flipt with Jaeger.
+Currently, we only support [Jaeger](https://www.jaegertracing.io/) as a tracing backend, however we are working on supporting others such as [Zipkin](https://zipkin.io/) and [OTLP](https://opentelemetry.io/docs/reference/specification/protocol/).
+
+### Jaeger
+
+Enable tracing via the values described in the [Tracing configuration](/configuration/overview#tracing) and point Flipt to your Jaeger host to record and export spans.
+
+There is an [example](https://github.com/flipt-io/flipt/tree/main/examples/tracing) provided in the GitHub repository showing how to set up Flipt with Jaeger.

--- a/configuration/overview.mdx
+++ b/configuration/overview.mdx
@@ -42,9 +42,6 @@ These properties are as follows:
 | ui.enabled             | Enable UI and API docs                                                                  | true                |         |
 | cors.enabled           | Enable CORS support                                                                     | false               | v0.7.0  |
 | cors.allowed_origins   | Sets Access-Control-Allow-Origin header on server                                       | "\*" (all domains)  | v0.7.0  |
-| tracing.jaeger.enabled | Enable tracing support with Jaeger                                                      | false               | v0.17.0 |
-| tracing.jaeger.host    | The UDP host destination to report spans                                                | localhost           | v0.17.0 |
-| tracing.jaeger.port    | The UDP port destination to report spans                                                | 6831                | v0.17.0 |
 | meta.check_for_updates | Enable check for newer versions of Flipt on startup                                     | true                | v0.17.0 |
 | meta.telemetry_enabled | Enable anonymous telemetry data (see [Telemetry](#telemetry))                           | true                | v1.8.0  |
 | meta.state_directory   | Directory on the host to store local state                                              | $HOME/.config/flipt | v1.8.0  |
@@ -60,6 +57,14 @@ These properties are as follows:
 | server.grpc_port  | The port on which to serve the Flipt GRPC server               | 9000    |        |
 | server.cert_file  | Path to the certificate file (if protocol is set to https)     |         | v0.8.0 |
 | server.cert_key   | Path to the certificate key file (if protocol is set to https) |         | v0.8.0 |
+
+### Tracing
+
+| Property               | Description                              | Default   | Since   |
+| ---------------------- | ---------------------------------------- | --------- | ------- |
+| tracing.jaeger.enabled | Enable tracing support with Jaeger       | false     | v0.17.0 |
+| tracing.jaeger.host    | The UDP host destination to report spans | localhost | v0.17.0 |
+| tracing.jaeger.port    | The UDP port destination to report spans | 6831      | v0.17.0 |
 
 ### Database
 
@@ -140,10 +145,8 @@ All deprecated configuration options will be removed from the documentation,
 however, they will still work as expected until they are removed. A warning will
 be logged in the Flipt logs when a deprecated configuration option is used.
 
-All deprecated options are listed in the
-[DEPRECATIONS](https://github.com/flipt-io/flipt/blob/main/DEPRECATIONS.md) file
-in the Flipt repository as well as the
-[CHANGELOG](https://github.com/flipt-io/flipt/blob/main/CHANGELOG.md).
+All deprecated options are listed in the [DEPRECATIONS](https://github.com/flipt-io/flipt/blob/main/DEPRECATIONS.md) file
+in the Flipt repository as well as the [CHANGELOG](https://github.com/flipt-io/flipt/blob/main/CHANGELOG.md).
 
 ## Environment Variables
 

--- a/configuration/storage.mdx
+++ b/configuration/storage.mdx
@@ -5,13 +5,10 @@ description: This document describes how to configure Flipt's storage backend me
 
 ## Databases
 
-Flipt supports [SQLite](https://www.sqlite.org/index.html),
-[Postgres](https://www.postgresql.org/),
-[CockroachDB](https://www.cockroachlabs.com/) and
+Flipt supports [SQLite](https://www.sqlite.org/index.html), [Postgres](https://www.postgresql.org/), [CockroachDB](https://www.cockroachlabs.com/) and
 [MySQL](https://dev.mysql.com/) databases.
 
-SQLite is enabled by default for simplicity, however you should use Postgres,
-MySQL, or CockroachDB if you intend to run multiple copies of Flipt in a high
+SQLite is enabled by default for simplicity, however you should use Postgres, MySQL, or CockroachDB if you intend to run multiple copies of Flipt in a high
 availability configuration.
 
 The database connection can be configured as follows:
@@ -181,7 +178,7 @@ Caching works as follows:
 - A cache hit will simply return the item from the cache, not interacting with
   the database
 
-See the [Cache](#cache) section for how to configure caching.
+See the [Cache](/configuration/overview#cache) section for how to configure caching.
 
 ### Expiration/Eviction
 


### PR DESCRIPTION
- update Tracing section to mention OTel instead of open tracing
- mention we are looking into supporting other trace backends
- move Tracing config to it's own section as it will likely expand soon
- fix some broken relative links