### PR TITLE
fix(oidc): reword client_token to client_secret

### DIFF
--- a/configuration/authentication.mdx
+++ b/configuration/authentication.mdx
@@ -91,7 +91,7 @@ authentication:
         some_provider: # insert your provider name here
           issuer_url: "https://some.oidc.issuer.com"
           client_id: "some_client_identifier"
-          client_token: "some_client_secret_credential"
+          client_secret: "some_client_secret_credential"
           redirect_address: "https://your.flipt.instance.url.com"
           scopes:
             - email
@@ -164,7 +164,7 @@ Using Google as an example and the documentation linked above, we obtained the f
 
 ```yaml
 client_id: "CyJcdvQMadOjSEx7ArArom0ytrbIHWd2Fb3N59oh8NQ="
-client_token: "WGgJmfQqN7cf17dFyZKXDL5S445/qhp+hfDAC0Mnl7oBrxgdAgiMyuwCkPiwfgQy"
+client_secret: "WGgJmfQqN7cf17dFyZKXDL5S445/qhp+hfDAC0Mnl7oBrxgdAgiMyuwCkPiwfgQy"
 ```
 
 We could create a provider definition in our configuration like so:
@@ -178,7 +178,7 @@ authentication:
         google:
           issuer_url: "https://accounts.google.com"
           client_id: "CyJcdvQMadOjSEx7ArArom0ytrbIHWd2Fb3N59oh8NQ="
-          client_token: "WGgJmfQqN7cf17dFyZKXDL5S445/qhp+hfDAC0Mnl7oBrxgdAgiMyuwCkPiwfgQy"
+          client_secret: "WGgJmfQqN7cf17dFyZKXDL5S445/qhp+hfDAC0Mnl7oBrxgdAgiMyuwCkPiwfgQy"
           redirect_address: "https://flipt.myorg.com"
           scopes:
             - email

--- a/configuration/overview.mdx
+++ b/configuration/overview.mdx
@@ -112,7 +112,7 @@ These properties are as follows:
 | authentication.methods.oidc.cleanup.grace_period                  | How long an expired token can exist until considered deletable | 30m     | v1.17.0 |
 | authentication.methods.oidc.providers.[provider].issuer_url       | Provider specific OIDC issuer URL (see your providers docs)    |         | v1.17.0 |
 | authentication.methods.oidc.providers.[provider].client_id        | Provider specific OIDC client ID (see your providers docs)     |         | v1.17.0 |
-| authentication.methods.oidc.providers.[provider].client_token     | Provider specific OIDC client token (see your providers docs)  |         | v1.17.0 |
+| authentication.methods.oidc.providers.[provider].client_secret    | Provider specific OIDC client secret (see your providers docs) |         | v1.17.0 |
 | authentication.methods.oidc.providers.[provider].redirect_address | Public URL on which this Flipt instance is reachable           |         | v1.17.0 |
 
 ### Cache


### PR DESCRIPTION
Fixes https://github.com/flipt-io/flipt-docs/issues/33

Changes `client_token` to `client_secret` as per configuration.