### PR TITLE
chore: update to mention multiple values for env vars; move logging to own section

### DIFF
--- a/configuration/overview.mdx
+++ b/configuration/overview.mdx
@@ -33,21 +33,26 @@ These properties are as follows:
 
 ### General
 
-| Property               | Description                                                                             | Default             | Since   |
-| ---------------------- | --------------------------------------------------------------------------------------- | ------------------- | ------- |
-| log.level              | Level at which messages are logged (trace, debug, info, warn, error, fatal, panic)      | info                |         |
-| log.grpc_level         | Level at which gRPC messages are logged (trace, debug, info, warn, error, fatal, panic) | error               | v1.12.0 |
-| log.file               | File to log to instead of STDOUT                                                        |                     | v0.10.0 |
-| log.encoding           | Encoding to use for logging (json, console)                                             | console             | v1.12.0 |
-| log.keys.time          | Structured logging key used when outputting log timestamp                               | T                   | v1.18.1 |
-| log.keys.level         | Structured logging key used when outputting log level                                   | L                   | v1.18.1 |
-| log.keys.message       | Structured logging key used when outputting log message                                 | M                   | v1.18.1 |
-| ui.enabled             | Enable UI and API docs                                                                  | true                |         |
-| cors.enabled           | Enable CORS support                                                                     | false               | v0.7.0  |
-| cors.allowed_origins   | Sets Access-Control-Allow-Origin header on server                                       | "\*" (all domains)  | v0.7.0  |
-| meta.check_for_updates | Enable check for newer versions of Flipt on startup                                     | true                | v0.17.0 |
-| meta.telemetry_enabled | Enable anonymous telemetry data (see [Telemetry](#telemetry))                           | true                | v1.8.0  |
-| meta.state_directory   | Directory on the host to store local state                                              | $HOME/.config/flipt | v1.8.0  |
+| Property               | Description                                                   | Default             | Since   |
+| ---------------------- | ------------------------------------------------------------- | ------------------- | ------- |
+| ui.enabled             | Enable UI and API docs                                        | true                |         |
+| cors.enabled           | Enable CORS support                                           | false               | v0.7.0  |
+| cors.allowed_origins   | Sets Access-Control-Allow-Origin header on server             | "\*" (all domains)  | v0.7.0  |
+| meta.check_for_updates | Enable check for newer versions of Flipt on startup           | true                | v0.17.0 |
+| meta.telemetry_enabled | Enable anonymous telemetry data (see [Telemetry](#telemetry)) | true                | v1.8.0  |
+| meta.state_directory   | Directory on the host to store local state                    | $HOME/.config/flipt | v1.8.0  |
+
+### Logging
+
+| Property         | Description                                                                             | Default | Since   |
+| ---------------- | --------------------------------------------------------------------------------------- | ------- | ------- |
+| log.level        | Level at which messages are logged (trace, debug, info, warn, error, fatal, panic)      | info    |         |
+| log.grpc_level   | Level at which gRPC messages are logged (trace, debug, info, warn, error, fatal, panic) | error   | v1.12.0 |
+| log.file         | File to log to instead of STDOUT                                                        |         | v0.10.0 |
+| log.encoding     | Encoding to use for logging (json, console)                                             | console | v1.12.0 |
+| log.keys.time    | Structured logging key used when outputting log timestamp                               | T       | v1.18.1 |
+| log.keys.level   | Structured logging key used when outputting log level                                   | L       | v1.18.1 |
+| log.keys.message | Structured logging key used when outputting log message                                 | M       | v1.18.1 |
 
 ### Server
 
@@ -134,6 +139,7 @@ These properties are as follows:
 | authentication.methods.oidc.providers.[provider].client_id        | Provider specific OIDC client ID (see your providers docs)     |         | v1.17.0 |
 | authentication.methods.oidc.providers.[provider].client_secret    | Provider specific OIDC client secret (see your providers docs) |         | v1.17.0 |
 | authentication.methods.oidc.providers.[provider].redirect_address | Public URL on which this Flipt instance is reachable           |         | v1.17.0 |
+| authentication.methods.oidc.providers.[provider].scopes           | Scopes to request from the provider                            |         | v1.17.0 |
 
 #### Authentication Methods: Kubernetes
 
@@ -197,7 +203,7 @@ FLIPT_<SectionName>_<KeyName>
   documentation.
 </Note>
 
-Everything should be uppercase, `.` should be replaced by `_`. For example,
+Keys should be uppercase and `.` should be replaced by `_`. For example,
 given these configuration settings:
 
 ```yaml
@@ -210,7 +216,17 @@ db:
 
 You can override them using:
 
-```yaml
-export FLIPT_SERVER_GRPC_PORT=9001 export
-FLIPT_DB_URL="postgres://postgres@localhost:5432/flipt?sslmode=disable"
+```console
+export FLIPT_SERVER_GRPC_PORT=9001
+export FLIPT_DB_URL="postgres://postgres@localhost:5432/flipt?sslmode=disable"
+```
+
+### Multiple Values
+
+Some configuration options can have a list of values. For example, the `cors.allowed_origins` option can have multiple origins.
+
+In this case, you can use a space separated list of values for the environment variable override:
+
+```console
+export FLIPT_CORS_ALLOWED_ORIGINS="http://localhost:3000 http://localhost:3001"
 ```


### PR DESCRIPTION
Re: https://github.com/flipt-io/flipt/pull/1370

- Add section on using env vars with multiple (list) of values
- Added `scopes` to configurable options
- Moved logging config to own subsection

![CleanShot 2023-03-02 at 09 17 13](https://user-images.githubusercontent.com/209477/222454325-cc69656e-918b-4bf0-be60-2eca260b8386.png)

![CleanShot 2023-03-02 at 09 17 20](https://user-images.githubusercontent.com/209477/222454349-e5c3e7bf-ecdf-4186-91d4-88eab9d9ccc2.png)
