### PR TITLE
feat: add documentation for audit events under observability section

### DIFF
--- a/configuration/observability.mdx
+++ b/configuration/observability.mdx
@@ -92,8 +92,11 @@ Starting from `v1.21.0`, Flipt supports sending audit events to configured sinks
   "metadata": {
     "type": "flag",
     "action": "created",
-    "ip": "127.0.0.1",
-    "author": "joe@example.com"
+    "actor": {
+      "ip": "127.0.0.1",
+      "method": "none",
+      "email": "joe@example.com"
+    }
   },
   "payload": {
     "description": "audit events feature",
@@ -106,7 +109,7 @@ Starting from `v1.21.0`, Flipt supports sending audit events to configured sinks
 ```
 
 - `version` : describes the version of the audit event structure. We do not expect too many changes to the structure of the audit event
-- `metadata`: information concerning the `type` and `action` taken with some identity metadata, `ip` and optional `author` if applicable
+- `metadata`: information concerning the `type` and `action` taken with some identity metadata in the `actor` object
 - `payload` : the actual payload used to interact with the `Flipt` server for certain auditable events
 
 

--- a/configuration/observability.mdx
+++ b/configuration/observability.mdx
@@ -112,7 +112,6 @@ Starting from `v1.21.0`, Flipt supports sending audit events to configured sinks
 - `metadata`: information concerning the `type` and `action` taken with some identity metadata in the `actor` object
 - `payload` : the actual payload used to interact with the `Flipt` server for certain auditable events
 
-
 Currently, we support the following sinks for audit events:
 
 - Log File: the audit events are JSON encoded and new-line delimited

--- a/configuration/observability.mdx
+++ b/configuration/observability.mdx
@@ -117,4 +117,4 @@ Currently, we support the following sinks for audit events:
 
 - Log File: the audit events are JSON encoded and new-line delimited
 
-You can find [examples]() on the main GitHub repository on how to enable audit events, and how to tune configuration for it.
+You can find [examples](https://github.com/flipt-io/flipt/tree/0f34a839c3e843443a8a8957cec44b928685091c/examples/audit) on the main GitHub repository on how to enable audit events, and how to tune configuration for it.

--- a/configuration/observability.mdx
+++ b/configuration/observability.mdx
@@ -81,3 +81,37 @@ Currently, we support the following tracing backends:
 Enable tracing via the values described in the [Tracing configuration](/configuration/overview#tracing) and point Flipt to your configured collector to record spans.
 
 There are [examples](https://github.com/flipt-io/flipt/tree/main/examples/tracing) provided in the main GitHub repository showing how to set up Flipt with each of the supported tracing backends.
+
+## Audit Events
+
+Starting from `v1.21.0`, Flipt will support sending audit events to configured sinks. The audit events will have the following payload as of `v0.1`:
+
+```json
+{
+  "version": "v0.1",
+  "metadata": {
+    "type": "flag",
+    "action": "created",
+    "ip": "127.0.0.1",
+    "author": "joe@example.com"
+  },
+  "payload": {
+    "description": "audit events feature",
+    "enabled": true,
+    "key": "my-audit-event",
+    "name": "myauditevent",
+    "namespace_key": "default"
+  }
+}
+```
+
+- `version`: describes the version of the audit event structure. We do not expect too many changes to the structure of the audit event
+- `metadata`: has information concerning the `type` and `action` taken with some identity metadata, `ip` and optional `author` if the server can find that information out
+- `payload`: is the actual payload used to interact with the `Flipt` server for certain auditable events
+
+
+Currently, we support the following sinks for audit events:
+
+- Log File: the audit events will be JSON encoded, with new line delimination
+
+You can find [examples]() on the main GitHub repository on how to enable audit events, and how to tune configuration for it.

--- a/configuration/observability.mdx
+++ b/configuration/observability.mdx
@@ -84,7 +84,7 @@ There are [examples](https://github.com/flipt-io/flipt/tree/main/examples/tracin
 
 ## Audit Events
 
-Starting from `v1.21.0`, Flipt will support sending audit events to configured sinks. The audit events will have the following payload as of `v0.1`:
+Starting from `v1.21.0`, Flipt supports sending audit events to configured sinks. Audit events have the following structure:
 
 ```json
 {
@@ -105,13 +105,13 @@ Starting from `v1.21.0`, Flipt will support sending audit events to configured s
 }
 ```
 
-- `version`: describes the version of the audit event structure. We do not expect too many changes to the structure of the audit event
-- `metadata`: has information concerning the `type` and `action` taken with some identity metadata, `ip` and optional `author` if the server can find that information out
-- `payload`: is the actual payload used to interact with the `Flipt` server for certain auditable events
+- `version` : describes the version of the audit event structure. We do not expect too many changes to the structure of the audit event
+- `metadata`: information concerning the `type` and `action` taken with some identity metadata, `ip` and optional `author` if applicable
+- `payload` : the actual payload used to interact with the `Flipt` server for certain auditable events
 
 
 Currently, we support the following sinks for audit events:
 
-- Log File: the audit events will be JSON encoded, with new line delimination
+- Log File: the audit events are JSON encoded and new-line delimited
 
 You can find [examples]() on the main GitHub repository on how to enable audit events, and how to tune configuration for it.

--- a/configuration/observability.mdx
+++ b/configuration/observability.mdx
@@ -88,14 +88,15 @@ Starting from `v1.21.0`, Flipt supports sending audit events to configured sinks
 
 ```json
 {
-  "version": "v0.1",
-  "metadata": {
+  "version": "0.1",
     "type": "flag",
     "action": "created",
-    "actor": {
-      "ip": "127.0.0.1",
-      "method": "none",
-      "email": "joe@example.com"
+    "metadata": {
+      "actor": {
+        "ip": "127.0.0.1",
+        "method": "none",
+        "email": "joe@example.com"
+      }
     }
   },
   "payload": {
@@ -108,8 +109,10 @@ Starting from `v1.21.0`, Flipt supports sending audit events to configured sinks
 }
 ```
 
-- `version` : describes the version of the audit event structure. We do not expect too many changes to the structure of the audit event
-- `metadata`: information concerning the `type` and `action` taken with some identity metadata in the `actor` object
+- `version` : the version of the audit event structure. We do not expect too many changes to the structure of the audit event
+- `type`    : the type of the entity being acted upon (flag, variant, constraint, etc.)
+- `action`  : the action taken upon the entity (created, deleted, updated, etc.)
+- `metadata`: extra information related to the audit event as a whole. The `actor` field will always be present containing some identity information of the source which initiated the audit event
 - `payload` : the actual payload used to interact with the `Flipt` server for certain auditable events
 
 Currently, we support the following sinks for audit events:

--- a/configuration/observability.mdx
+++ b/configuration/observability.mdx
@@ -89,14 +89,13 @@ Starting from `v1.21.0`, Flipt supports sending audit events to configured sinks
 ```json
 {
   "version": "0.1",
-    "type": "flag",
-    "action": "created",
-    "metadata": {
-      "actor": {
-        "ip": "127.0.0.1",
-        "method": "none",
-        "email": "joe@example.com"
-      }
+  "type": "flag",
+  "action": "created",
+  "metadata": {
+    "actor": {
+      "ip": "127.0.0.1",
+      "authentication": "none",
+      "email": "joe@example.com"
     }
   },
   "payload": {
@@ -105,15 +104,17 @@ Starting from `v1.21.0`, Flipt supports sending audit events to configured sinks
     "key": "my-audit-event",
     "name": "myauditevent",
     "namespace_key": "default"
-  }
+  },
+  "timestamp": "1970-01-01T00:00:00-00:00"
 }
 ```
 
-- `version` : the version of the audit event structure. We do not expect too many changes to the structure of the audit event
-- `type`    : the type of the entity being acted upon (flag, variant, constraint, etc.)
-- `action`  : the action taken upon the entity (created, deleted, updated, etc.)
-- `metadata`: extra information related to the audit event as a whole. The `actor` field will always be present containing some identity information of the source which initiated the audit event
-- `payload` : the actual payload used to interact with the `Flipt` server for certain auditable events
+- `version`  : the version of the audit event structure. We do not expect too many changes to the structure of the audit event
+- `type`     : the type of the entity being acted upon (flag, variant, constraint, etc.)
+- `action`   : the action taken upon the entity (created, deleted, updated, etc.)
+- `metadata` : extra information related to the audit event as a whole. The `actor` field will always be present containing some identity information of the source which initiated the audit event
+- `payload`  : the actual payload used to interact with the `Flipt` server for certain auditable events
+- `timestamp`: the time the event was created
 
 Currently, we support the following sinks for audit events:
 

--- a/configuration/observability.mdx
+++ b/configuration/observability.mdx
@@ -118,6 +118,6 @@ Starting from `v1.21.0`, Flipt supports sending audit events to configured sinks
 
 Currently, we support the following sinks for audit events:
 
-- Log File: the audit events are JSON encoded and new-line delimited
+- Log File: the audit events are JSON encoded and new-line delimited. Configuration found [here](/configuration/overview#audit-events-log-file)
 
 You can find [examples](https://github.com/flipt-io/flipt/tree/0f34a839c3e843443a8a8957cec44b928685091c/examples/audit) on the main GitHub repository on how to enable audit events, and how to tune configuration for it.

--- a/configuration/observability.mdx
+++ b/configuration/observability.mdx
@@ -93,19 +93,18 @@ Starting from `v1.21.0`, Flipt supports sending audit events to configured sinks
   "action": "created",
   "metadata": {
     "actor": {
-      "ip": "127.0.0.1",
       "authentication": "none",
-      "email": "joe@example.com"
+      "ip": "172.17.0.1"
     }
   },
   "payload": {
-    "description": "audit events feature",
+    "description": "flipt flag",
     "enabled": true,
-    "key": "my-audit-event",
-    "name": "myauditevent",
+    "key": "flipt",
+    "name": "flipt",
     "namespace_key": "default"
   },
-  "timestamp": "1970-01-01T00:00:00-00:00"
+  "timestamp": "1970-01-01T00:00:00Z"
 }
 ```
 

--- a/configuration/overview.mdx
+++ b/configuration/overview.mdx
@@ -89,10 +89,10 @@ These properties are as follows:
 
 ### Audit Events: Log File
 
-| Property                 | Description                                | Default        | Since   |
-| ------------------------ | ------------------------------------------ | -------------- | ------- |
-| audit.sinks.log.enabled  | Enable log file sink                       | false          | v1.21.0 |
-| audit.sinks.log.path     | File path to send audit events to          | $(PWD)/log.txt | v1.21.0 |
+| Property                 | Description                                                               | Default | Since   |
+| ------------------------ | ------------------------------------------------------------------------- | ------- | ------- |
+| audit.sinks.log.enabled  | Enable log file sink                                                      | false   | v1.21.0 |
+| audit.sinks.log.file     | File path to send audit events to, needs to be set if log file is enabled |         | v1.21.0 |
 
 #### Tracing: Zipkin
 

--- a/configuration/overview.mdx
+++ b/configuration/overview.mdx
@@ -80,6 +80,20 @@ These properties are as follows:
 | tracing.jaeger.host | The UDP host destination to report spans | localhost | v0.17.0 |
 | tracing.jaeger.port | The UDP port destination to report spans | 6831      | v0.17.0 |
 
+### Audit Events
+
+| Property                 | Description                                     | Default | Since   |
+| ------------------------ | ----------------------------------------------- | ------- | ------- |
+| audit.buffer.capacity    | Max capacity of buffer to send events to sinks  | 2       | v1.21.0 |
+| audit.buffer.flushPeriod | Duration to wait before sending events to sinks | 2m      | v1.21.0 |
+
+### Audit Events: Log File
+
+| Property                 | Description                                | Default        | Since   |
+| ------------------------ | ------------------------------------------ | -------------- | ------- |
+| audit.sinks.log.enabled  | Enable log file sink                       | false          | v1.21.0 |
+| audit.sinks.log.path     | File path to send audit events to          | $(PWD)/log.txt | v1.21.0 |
+
 #### Tracing: Zipkin
 
 | Property                | Description                             | Default                            | Since   |

--- a/configuration/overview.mdx
+++ b/configuration/overview.mdx
@@ -92,7 +92,7 @@ These properties are as follows:
 | Property                 | Description                                                               | Default | Since   |
 | ------------------------ | ------------------------------------------------------------------------- | ------- | ------- |
 | audit.sinks.log.enabled  | Enable log file sink                                                      | false   | v1.21.0 |
-| audit.sinks.log.file     | File path to send audit events to, needs to be set if log file is enabled |         | v1.21.0 |
+| audit.sinks.log.file     | File path to write audit events to. Required if log file sink is enabled |         | v1.21.0 |
 
 #### Tracing: Zipkin
 


### PR DESCRIPTION
Documentation for Audit Events feature that will be released in `v1.21.0`.

Completes FLI-305