### PR TITLE
fix: namespaces paths for API docs

### DIFF
--- a/reference/constraints/create-constraint.mdx
+++ b/reference/constraints/create-constraint.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: "POST /api/v1/segments/{segmentKey}/constraints"
+openapi: "POST /api/v1/namespaces/{namespaceKey}/segments/{segmentKey}/constraints"
 ---

--- a/reference/constraints/delete-constraint.mdx
+++ b/reference/constraints/delete-constraint.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: "DELETE /api/v1/segments/{segmentKey}/constraints/{id}"
+openapi: "DELETE /api/v1/namespaces/{namespaceKey}/segments/{segmentKey}/constraints/{id}"
 ---

--- a/reference/constraints/update-constraint.mdx
+++ b/reference/constraints/update-constraint.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: "PUT /api/v1/segments/{segmentKey}/constraints/{id}"
+openapi: "PUT /api/v1/namespaces/{namespaceKey}/segments/{segmentKey}/constraints/{id}"
 ---

--- a/reference/distributions/create-distribution.mdx
+++ b/reference/distributions/create-distribution.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: "POST /api/v1/flags/{flagKey}/rules/{ruleId}/distributions"
+openapi: "POST /api/v1/namespaces/{namespaceKey}/flags/{flagKey}/rules/{ruleId}/distributions"
 ---

--- a/reference/distributions/delete-distribution.mdx
+++ b/reference/distributions/delete-distribution.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: "DELETE /api/v1/flags/{flagKey}/rules/{ruleId}/distributions/{id}"
+openapi: "DELETE /api/v1/namespaces/{namespaceKey}/flags/{flagKey}/rules/{ruleId}/distributions/{id}"
 ---

--- a/reference/distributions/update-distribution.mdx
+++ b/reference/distributions/update-distribution.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: "PUT /api/v1/flags/{flagKey}/rules/{ruleId}/distributions/{id}"
+openapi: "PUT /api/v1/namespaces/{namespaceKey}/flags/{flagKey}/rules/{ruleId}/distributions/{id}"
 ---

--- a/reference/evaluate/batch-evaluate.mdx
+++ b/reference/evaluate/batch-evaluate.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: "POST /api/v1/batch-evaluate"
+openapi: "POST /api/v1/namespaces/{namespaceKey}/batch-evaluate"
 ---

--- a/reference/evaluate/evaluate.mdx
+++ b/reference/evaluate/evaluate.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: "POST /api/v1/evaluate"
+openapi: "POST /api/v1/namespaces/{namespaceKey}/evaluate"
 ---

--- a/reference/flags/create-flag.mdx
+++ b/reference/flags/create-flag.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: "POST /api/v1/flags"
+openapi: "POST /api/v1/namespaces/{namespaceKey}/flags"
 ---

--- a/reference/flags/delete-flag.mdx
+++ b/reference/flags/delete-flag.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: "DELETE /api/v1/flags/{key}"
+openapi: "DELETE /api/v1/namespaces/{namespaceKey}/flags/{key}"
 ---

--- a/reference/flags/get-flag.mdx
+++ b/reference/flags/get-flag.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: "GET /api/v1/flags/{key}"
+openapi: "GET /api/v1/namespaces/{namespaceKey}/flags/{key}"
 ---

--- a/reference/flags/list-flags.mdx
+++ b/reference/flags/list-flags.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: "GET /api/v1/flags"
+openapi: "GET /api/v1/namespaces/{namespaceKey}/flags"
 ---

--- a/reference/flags/update-flag.mdx
+++ b/reference/flags/update-flag.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: "PUT /api/v1/flags/{key}"
+openapi: "PUT /api/v1/namespaces/{namespaceKey}/flags/{key}"
 ---

--- a/reference/rules/create-rule.mdx
+++ b/reference/rules/create-rule.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: "POST /api/v1/flags/{flagKey}/rules"
+openapi: "POST /api/v1/namespaces/{namespaceKey}/flags/{flagKey}/rules"
 ---

--- a/reference/rules/delete-rule.mdx
+++ b/reference/rules/delete-rule.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: "DELETE /api/v1/flags/{flagKey}/rules/{id}"
+openapi: "DELETE /api/v1/namespaces/{namespaceKey}/flags/{flagKey}/rules/{id}"
 ---

--- a/reference/rules/get-rule.mdx
+++ b/reference/rules/get-rule.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: "GET /api/v1/flags/{flagKey}/rules/{id}"
+openapi: "GET /api/v1/namespaces/{namespaceKey}/flags/{flagKey}/rules/{id}"
 ---

--- a/reference/rules/list-rules.mdx
+++ b/reference/rules/list-rules.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: "GET /api/v1/flags/{flagKey}/rules"
+openapi: "GET /api/v1/namespaces/{namespaceKey}/flags/{flagKey}/rules"
 ---

--- a/reference/rules/order-rules.mdx
+++ b/reference/rules/order-rules.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: "PUT /api/v1/flags/{flagKey}/rules/order"
+openapi: "PUT /api/v1/namespaces/{namespaceKey}/flags/{flagKey}/rules/order"
 ---

--- a/reference/rules/update-rule.mdx
+++ b/reference/rules/update-rule.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: "PUT /api/v1/flags/{flagKey}/rules/{id}"
+openapi: "PUT /api/v1/namespaces/{namespaceKey}/flags/{flagKey}/rules/{id}"
 ---

--- a/reference/segments/create-segment.mdx
+++ b/reference/segments/create-segment.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: "POST /api/v1/segments"
+openapi: "POST /api/v1/namespaces/{namespaceKey}/segments"
 ---

--- a/reference/segments/delete-segment.mdx
+++ b/reference/segments/delete-segment.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: "DELETE /api/v1/segments/{key}"
+openapi: "DELETE /api/v1/namespaces/{namespaceKey}/segments/{key}"
 ---

--- a/reference/segments/get-segment.mdx
+++ b/reference/segments/get-segment.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: "GET /api/v1/segments/{key}"
+openapi: "GET /api/v1/namespaces/{namespaceKey}/segments/{key}"
 ---

--- a/reference/segments/list-segment.mdx
+++ b/reference/segments/list-segment.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: "GET /api/v1/segments"
+openapi: "GET /api/v1/namespaces/{namespaceKey}/segments"
 ---

--- a/reference/segments/update-segment.mdx
+++ b/reference/segments/update-segment.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: "PUT /api/v1/segments/{key}"
+openapi: "PUT /api/v1/namespaces/{namespaceKey}/segments/{key}"
 ---

--- a/reference/variants/create-variant.mdx
+++ b/reference/variants/create-variant.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: "POST /api/v1/flags/{flagKey}/variants"
+openapi: "POST /api/v1/namespaces/{namespaceKey}/flags/{flagKey}/variants"
 ---

--- a/reference/variants/delete-variant.mdx
+++ b/reference/variants/delete-variant.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: "DELETE /api/v1/flags/{flagKey}/variants/{id}"
+openapi: "DELETE /api/v1/namespaces/{namespaceKey}/flags/{flagKey}/variants/{id}"
 ---

--- a/reference/variants/update-variant.mdx
+++ b/reference/variants/update-variant.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: "PUT /api/v1/flags/{flagKey}/variants/{id}"
+openapi: "PUT /api/v1/namespaces/{namespaceKey}/flags/{flagKey}/variants/{id}"
 ---


### PR DESCRIPTION
fix: namespaces paths for API docs