### PR TITLE
chore: Updates for v1.20

### DIFF
--- a/integration.mdx
+++ b/integration.mdx
@@ -12,8 +12,8 @@ would like to be able to use with Flipt.
 
 There are two ways to communicate with the Flipt server:
 
-1. GRPC API
 1. REST API
+1. GRPC API
 
 We have also developed several clients in various languages for easier integration.
 
@@ -22,6 +22,40 @@ We have also developed several clients in various languages for easier integrati
 These SDKs support both Flipt's gRPC and HTTP RPC APIs:
 
 - [Go](https://github.com/flipt-io/flipt/tree/main/sdk/go)
+
+## REST API
+
+Flipt also comes equipped with a fully functional REST API. The Flipt UI is completely backed by this same API. This means that anything that can be done in the Flipt UI can also be done via the REST API.
+
+The Flipt REST API can also be used with any language that can make HTTP requests. This means that you don't need to use one of the above GRPC clients to integrate your application with Flipt.
+
+The latest version of the REST API is fully documented using the [OpenAPI v3 specification](https://github.com/flipt-io/flipt-openapi) as well as the above [API Reference](/reference/overview).
+
+## REST Clients
+
+### Official Clients
+
+Official Flipt REST clients are currently available in the following languages:
+
+- [Go](https://github.com/flipt-io/flipt/tree/main/sdk/go)
+- [Node.js/TypeScript](https://github.com/flipt-io/flipt-node)
+- [Java](https://github.com/flipt-io/flipt-java)
+- [Rust](https://github.com/flipt-io/flipt-rust)
+
+### Generate
+
+You can use [openapi-generator](https://openapi-generator.tech/) to generate client code in your preferred language from the [Flipt OpenAPI v3 specification](https://github.com/flipt-io/flipt-openapi).
+
+While generating clients is outside of the scope of this documentation, an example of generating a Java client with the `openapi-generator` is below.
+
+#### Java Example
+
+1. Install [`openapi-generator`](https://openapi-generator.tech/docs/installation)
+2. Generate using `openapi-generator-cli` to desired location:
+
+```
+openapi-generator generate -i openapi.yml -g java -o /tmp/flipt/java
+```
 
 ## GRPC Clients
 
@@ -94,40 +128,6 @@ grpc_tools_ruby_protoc -I ./rpc --ruby_out=/tmp/flipt/ruby --grpc_out=/tmp/flipt
 cd /tmp/flipt/ruby
 ls
 flipt_pb.rb          flipt_services_pb.rb
-```
-
-## REST API
-
-Flipt also comes equipped with a fully functional REST API. The Flipt UI is completely backed by this same API. This means that anything that can be done in the Flipt UI can also be done via the REST API.
-
-The Flipt REST API can also be used with any language that can make HTTP requests. This means that you don't need to use one of the above GRPC clients to integrate your application with Flipt.
-
-The latest version of the REST API is fully documented using the [OpenAPI v3 specification](https://github.com/flipt-io/flipt-openapi) as well as the above [API Reference](/reference/overview).
-
-## REST Clients
-
-### Official Clients
-
-Official Flipt REST clients are currently available in the following languages:
-
-- [Go](https://github.com/flipt-io/flipt/tree/main/sdk/go)
-- [Node.js/TypeScript](https://github.com/flipt-io/flipt-node)
-- [Java](https://github.com/flipt-io/flipt-java)
-- [Rust](https://github.com/flipt-io/flipt-rust)
-
-### Generate
-
-You can use [openapi-generator](https://openapi-generator.tech/) to generate client code in your preferred language from the [Flipt OpenAPI v3 specification](https://github.com/flipt-io/flipt-openapi).
-
-While generating clients is outside of the scope of this documentation, an example of generating a Java client with the `openapi-generator` is below.
-
-#### Java Example
-
-1. Install [`openapi-generator`](https://openapi-generator.tech/docs/installation)
-2. Generate using `openapi-generator-cli` to desired location:
-
-```
-openapi-generator generate -i openapi.yml -g java -o /tmp/flipt/java
 ```
 
 ## Third-Party Client Libraries

--- a/integration.mdx
+++ b/integration.mdx
@@ -17,12 +17,6 @@ There are two ways to communicate with the Flipt server:
 
 We have also developed several clients in various languages for easier integration.
 
-## GRPC + REST SDKs
-
-These SDKs support both Flipt's gRPC and HTTP RPC APIs:
-
-- [Go](https://github.com/flipt-io/flipt/tree/main/sdk/go)
-
 ## REST API
 
 Flipt also comes equipped with a fully functional REST API. The Flipt UI is completely backed by this same API. This means that anything that can be done in the Flipt UI can also be done via the REST API.
@@ -37,7 +31,7 @@ The latest version of the REST API is fully documented using the [OpenAPI v3 spe
 
 Official Flipt REST clients are currently available in the following languages:
 
-- [Go](https://github.com/flipt-io/flipt/tree/main/sdk/go)
+- [Go](https://pkg.go.dev/go.flipt.io/flipt/sdk/go)
 - [Node.js/TypeScript](https://github.com/flipt-io/flipt-node)
 - [Java](https://github.com/flipt-io/flipt-java)
 - [Rust](https://github.com/flipt-io/flipt-rust)
@@ -83,7 +77,7 @@ integrate with Flipt using the Go GRPC client.
 
 Official Flipt GRPC clients are currently available for the following languages:
 
-- [Go](https://github.com/flipt-io/flipt-grpc-go)
+- [Go](https://github.com/flipt-io/flipt-grpc-go) - deprecated: use [Go SDK](https://pkg.go.dev/go.flipt.io/flipt/sdk/go) instead
 - [Ruby](https://github.com/flipt-io/flipt-grpc-ruby)
 
 If your language is not listed, please see the section below on how to generate

--- a/mint.json
+++ b/mint.json
@@ -1,6 +1,5 @@
 {
   "name": "Flipt",
-  "versions": ["v1.20.0+"],
   "logo": {
     "light": "/logo/light-logo.svg",
     "dark": "/logo/dark-logo.svg"
@@ -83,11 +82,10 @@
     },
     {
       "group": "Overview",
-      "pages": ["reference/overview"],
-      "version": "v1.20.0+"
+      "pages": ["reference/overview"]
     },
     {
-      "group": "API Authentication",
+      "group": "Authentication",
       "pages": [
         "reference/authentication/list-tokens",
         "reference/authentication/get-token",
@@ -95,34 +93,23 @@
         "reference/authentication/create-token",
         "reference/authentication/get-self",
         "reference/authentication/expire-self"
-      ],
-      "version": "v1.20.0+"
-    },
-    {
-      "group": "Constraints",
-      "pages": [
-        "reference/constraints/create-constraint",
-        "reference/constraints/delete-constraint",
-        "reference/constraints/update-constraint"
-      ],
-      "version": "v1.20.0+"
-    },
-    {
-      "group": "Distributions",
-      "pages": [
-        "reference/distributions/create-distribution",
-        "reference/distributions/delete-distribution",
-        "reference/distributions/update-distribution"
-      ],
-      "version": "v1.20.0+"
+      ]
     },
     {
       "group": "Evaluation",
       "pages": [
         "reference/evaluate/batch-evaluate",
         "reference/evaluate/evaluate"
-      ],
-      "version": "v1.20.0+"
+      ]
+    },
+    {
+      "group": "Namespaces",
+      "pages": [
+        "reference/namespaces/list-namespaces",
+        "reference/namespaces/create-namespace",
+        "reference/namespaces/delete-namespace",
+        "reference/namespaces/update-namespace"
+      ]
     },
     {
       "group": "Flags",
@@ -132,8 +119,33 @@
         "reference/flags/get-flag",
         "reference/flags/delete-flag",
         "reference/flags/update-flag"
-      ],
-      "version": "v1.20.0+"
+      ]
+    },
+    {
+      "group": "Variants",
+      "pages": [
+        "reference/variants/create-variant",
+        "reference/variants/delete-variant",
+        "reference/variants/update-variant"
+      ]
+    },
+    {
+      "group": "Segments",
+      "pages": [
+        "reference/segments/list-segment",
+        "reference/segments/create-segment",
+        "reference/segments/get-segment",
+        "reference/segments/delete-segment",
+        "reference/segments/update-segment"
+      ]
+    },
+    {
+      "group": "Constraints",
+      "pages": [
+        "reference/constraints/create-constraint",
+        "reference/constraints/delete-constraint",
+        "reference/constraints/update-constraint"
+      ]
     },
     {
       "group": "Rules",
@@ -144,28 +156,15 @@
         "reference/rules/get-rule",
         "reference/rules/delete-rule",
         "reference/rules/update-rule"
-      ],
-      "version": "v1.20.0+"
+      ]
     },
     {
-      "group": "Segments",
+      "group": "Distributions",
       "pages": [
-        "reference/segments/list-segment",
-        "reference/segments/create-segment",
-        "reference/segments/get-segment",
-        "reference/segments/delete-segment",
-        "reference/segments/update-segment"
-      ],
-      "version": "v1.20.0+"
-    },
-    {
-      "group": "Variants",
-      "pages": [
-        "reference/variants/create-variant",
-        "reference/variants/delete-variant",
-        "reference/variants/update-variant"
-      ],
-      "version": "v1.20.0+"
+        "reference/distributions/create-distribution",
+        "reference/distributions/delete-distribution",
+        "reference/distributions/update-distribution"
+      ]
     }
   ],
   "footerSocials": {

--- a/mint.json
+++ b/mint.json
@@ -1,5 +1,6 @@
 {
   "name": "Flipt",
+  "versions": ["v1.20.0+"],
   "logo": {
     "light": "/logo/light-logo.svg",
     "dark": "/logo/dark-logo.svg"
@@ -82,7 +83,8 @@
     },
     {
       "group": "Overview",
-      "pages": ["reference/overview"]
+      "pages": ["reference/overview"],
+      "version": "v1.20.0+"
     },
     {
       "group": "API Authentication",
@@ -92,11 +94,9 @@
         "reference/authentication/delete-token",
         "reference/authentication/create-token",
         "reference/authentication/get-self",
-        "reference/authentication/expire-self",
-        "reference/authentication/oidc-authorize",
-        "reference/authentication/oidc-callback",
-        "reference/authentication/kubernetes-verify-service-account"
-      ]
+        "reference/authentication/expire-self"
+      ],
+      "version": "v1.20.0+"
     },
     {
       "group": "Constraints",
@@ -104,7 +104,8 @@
         "reference/constraints/create-constraint",
         "reference/constraints/delete-constraint",
         "reference/constraints/update-constraint"
-      ]
+      ],
+      "version": "v1.20.0+"
     },
     {
       "group": "Distributions",
@@ -112,14 +113,16 @@
         "reference/distributions/create-distribution",
         "reference/distributions/delete-distribution",
         "reference/distributions/update-distribution"
-      ]
+      ],
+      "version": "v1.20.0+"
     },
     {
       "group": "Evaluation",
       "pages": [
         "reference/evaluate/batch-evaluate",
         "reference/evaluate/evaluate"
-      ]
+      ],
+      "version": "v1.20.0+"
     },
     {
       "group": "Flags",
@@ -129,7 +132,8 @@
         "reference/flags/get-flag",
         "reference/flags/delete-flag",
         "reference/flags/update-flag"
-      ]
+      ],
+      "version": "v1.20.0+"
     },
     {
       "group": "Rules",
@@ -140,7 +144,8 @@
         "reference/rules/get-rule",
         "reference/rules/delete-rule",
         "reference/rules/update-rule"
-      ]
+      ],
+      "version": "v1.20.0+"
     },
     {
       "group": "Segments",
@@ -150,7 +155,8 @@
         "reference/segments/get-segment",
         "reference/segments/delete-segment",
         "reference/segments/update-segment"
-      ]
+      ],
+      "version": "v1.20.0+"
     },
     {
       "group": "Variants",
@@ -158,7 +164,8 @@
         "reference/variants/create-variant",
         "reference/variants/delete-variant",
         "reference/variants/update-variant"
-      ]
+      ],
+      "version": "v1.20.0+"
     }
   ],
   "footerSocials": {

--- a/mint.json
+++ b/mint.json
@@ -8,6 +8,9 @@
     "baseUrl": "https://try.flipt.io",
     "auth": {
       "method": "bearer"
+    },
+    "playground": {
+      "mode": "simple"
     }
   },
   "favicon": "/favicon.svg",
@@ -107,6 +110,7 @@
       "pages": [
         "reference/namespaces/list-namespaces",
         "reference/namespaces/create-namespace",
+        "reference/namespaces/get-namespace",
         "reference/namespaces/delete-namespace",
         "reference/namespaces/update-namespace"
       ]

--- a/reference/authentication/kubernetes-verify-service-account.mdx
+++ b/reference/authentication/kubernetes-verify-service-account.mdx
@@ -1,3 +1,0 @@
----
-openapi: "POST /auth/v1/method/kubernetes/serviceaccount"
----

--- a/reference/authentication/oidc-authorize.mdx
+++ b/reference/authentication/oidc-authorize.mdx
@@ -1,3 +1,0 @@
----
-openapi: "GET /auth/v1/method/oidc/{provider}/authorize"
----

--- a/reference/authentication/oidc-callback.mdx
+++ b/reference/authentication/oidc-callback.mdx
@@ -1,3 +1,0 @@
----
-openapi: "GET /auth/v1/method/oidc/{provider}/callback"
----

--- a/reference/namespaces/create-namespace.mdx
+++ b/reference/namespaces/create-namespace.mdx
@@ -1,0 +1,3 @@
+---
+openapi: "POST /api/v1/namespaces"
+---

--- a/reference/namespaces/delete-namespace.mdx
+++ b/reference/namespaces/delete-namespace.mdx
@@ -1,0 +1,3 @@
+---
+openapi: "DELETE /api/v1/namespaces/{key}"
+---

--- a/reference/namespaces/get-namespace.mdx
+++ b/reference/namespaces/get-namespace.mdx
@@ -1,0 +1,3 @@
+---
+openapi: "GET /api/v1/namespaces/{key}"
+---

--- a/reference/namespaces/list-namespaces.mdx
+++ b/reference/namespaces/list-namespaces.mdx
@@ -1,0 +1,3 @@
+---
+openapi: "GET /api/v1/namespaces"
+---

--- a/reference/namespaces/update-namespace.mdx
+++ b/reference/namespaces/update-namespace.mdx
@@ -1,0 +1,3 @@
+---
+openapi: "PUT /api/v1/namespaces/{key}"
+---

--- a/reference/overview.mdx
+++ b/reference/overview.mdx
@@ -10,8 +10,29 @@ The Flipt REST API can also be used with any language that can make HTTP request
 
 The latest version of the REST API is fully documented using the [OpenAPI v3 specification](https://github.com/flipt-io/flipt-openapi).
 
-There are also official client SDKs for JavaScript, Java, and Rust:
+## Backward Compatability
 
+We take great care to ensure that the Flipt REST API is backward compatible. This means that you can safely upgrade to a newer version of Flipt without having to change your API calls.
+
+From time to time we may need to make large changes to the API as we introduce additional features, however we will continue to make sure that we preserve backward compatability.
+
+We will describe any major changes in the section below.
+
+## API Changes
+
+### v1.20.0
+
+Version [v1.20.0](https://github.com/flipt-io/flipt/releases/tag/v1.20.0) of Flipt introduced the concept of Namespaces as root objects nested under the `/namespaces` route (ie: `/api/v1/namespace/{namespaceKey}/flags`).
+
+All previous endpoints without the `/namespaces` prefix still work as before (ie: `/api/v1/flags`), they simply resolve to using the **default** namespace.
+
+See the [Concepts: Namespaces](/concepts#namespaces) section for more infomation.
+
+## SDKs
+
+There are official REST client SDKs for Go, JavaScript, Java, and Rust:
+
+- [flipt-go](https://github.com/flipt-io/flipt/tree/main/sdk/go)
 - [flipt-node](https://github.com/flipt-io/flipt-node)
 - [flipt-java](https://github.com/flipt-io/flipt-java)
 - [flipt-rust](https://github.com/flipt-io/flipt-rust) 

--- a/reference/overview.mdx
+++ b/reference/overview.mdx
@@ -2,7 +2,7 @@
 title: API Overview
 ---
 
-Flipt's API is the primary way to interact with Flipt outside of the UI. It is used to create, update, and delete entities such as flags, segments, and rules. It is also used to evaluate flags.
+Flipt's API is the primary way to interact with Flipt outside of the UI. It is used to create, update, and delete entities such as namespaces, flags, segments, and rules. It is also used to evaluate flags.
 
 The Flipt UI is completely backed by this same API. This means that anything that can be done in the Flipt UI can also be done via the REST API.
 
@@ -14,7 +14,7 @@ There are also official client SDKs for JavaScript, Java, and Rust:
 
 - [flipt-node](https://github.com/flipt-io/flipt-node)
 - [flipt-java](https://github.com/flipt-io/flipt-java)
-- [flipt-rust](https://github.com/flipt-io/flipt-rust) (beta)
+- [flipt-rust](https://github.com/flipt-io/flipt-rust) 
 
 <Note>
 We're working on more REST API SDKs and would love to hear from you if you're

--- a/reference/overview.mdx
+++ b/reference/overview.mdx
@@ -10,11 +10,11 @@ The Flipt REST API can also be used with any language that can make HTTP request
 
 The latest version of the REST API is fully documented using the [OpenAPI v3 specification](https://github.com/flipt-io/flipt-openapi).
 
-## Backward Compatability
+## Backward Compatibility
 
 We take great care to ensure that the Flipt REST API is backward compatible. This means that you can safely upgrade to a newer version of Flipt without having to change your API calls.
 
-From time to time we may need to make large changes to the API as we introduce additional features, however we will continue to make sure that we preserve backward compatability.
+From time to time we may need to make large changes to the API as we introduce additional features, however we will continue to make sure that we preserve backward compatibility.
 
 We will describe any major changes in the section below.
 


### PR DESCRIPTION
Fixes: FLI-307

This PR updates the docs post [v1.20.0](https://github.com/flipt-io/flipt/releases/tag/v1.20.0) release.

- Swap GRPC and REST API order in the docs
- Add section on backward compatibility to API docs overview
- Add Go REST SDK link
- Make the REST API docs simpler/cleaner by disabling the interactivity mode: https://mintlify.com/docs/api-playground/overview#playground-settings
- Adds `namespaces` section/routes to the REST API Docs
- Reorders the REST API docs to a more natural ordering instead of alphabetical