### PR TITLE
chore: update telemetry docs

### DIFF
--- a/configuration/observability.mdx
+++ b/configuration/observability.mdx
@@ -1,40 +1,7 @@
 ---
 title: Observability
-description: This document describes how to configure Flipt's telemetry outputs.
+description: This document describes how to configure Flipt's observability mechanisms including metrics and tracing.
 ---
-
-## Telemetry
-
-Flipt developers rely on anonymous usage data to help prioritize new features
-and improve the product. The information collected is completely anonymous,
-never shared with external entities, and you can opt-out at any time.
-
-### What Kind of Data is Collected?
-
-- Flipt version
-
-You can view the full schema of the telemetry data on
-[GitHub](https://github.com/flipt-io/flipt/blob/05b85f6ec704d9eac850984c16d9bc3d15dbdb6c/internal/telemetry/telemetry.go#L26-L30).
-
-We use [Segment](https://segment.com) to collect the data. Only the creator of
-Flipt has access to the data.
-
-### How to Disable Telemetry
-
-There are multiple ways in which you can disable telemetry collection:
-
-#### Configuration File
-
-```yaml
-meta:
-  telemetry_enabled: false
-```
-
-#### Environment Variable
-
-```yaml
-export FLIPT_TELEMETRY_ENABLED=false
-```
 
 ## Metrics
 

--- a/configuration/telemetry.mdx
+++ b/configuration/telemetry.mdx
@@ -1,0 +1,61 @@
+---
+title: Telemetry
+description: This document describes how to configure Flipt's telemetry outputs as well as what data is captured.
+---
+
+## Telemetry
+
+Flipt developers rely on anonymous usage data to help prioritize new features
+and improve the product. The information collected is completely anonymous,
+never shared with external entities, and you can opt-out at any time.
+
+### What Kind of Data is Collected?
+
+- Flipt version (ie: v1.20.0)
+- Database backend (ie: Postgres)
+- Cache backend (ie: Redis)
+- Authentication methods (ie: OIDC)
+
+We use [Segment](https://segment.com) to collect the data. Only the creator of
+Flipt has access to the raw data.
+
+Here is an example of the telemetry data sent to Segment:
+
+```json
+{
+    "version": "1.1",
+    "uuid": "1545d8a8-7a66-4d8d-a158-0a1c576c68a6",
+    "lastTimestamp": "2023-04-25T01:01:51Z",
+    "flipt": {
+        "version": "v1.20.1",
+        "storage": {
+            "database": "postgres",
+            "cache": "redis"
+        },
+        "authentication": {
+            "methods": "oidc"
+        }
+    }
+}
+```
+
+You can view the full schema of the telemetry data on
+[GitHub](https://github.com/flipt-io/flipt/blob/05b85f6ec704d9eac850984c16d9bc3d15dbdb6c/internal/telemetry/telemetry.go#L26-L30).
+
+
+### How to Disable Telemetry
+
+There are multiple ways in which you can disable telemetry collection:
+
+#### Configuration File
+
+```yaml
+meta:
+  telemetry_enabled: false
+```
+
+#### Environment Variable
+
+```yaml
+export FLIPT_TELEMETRY_ENABLED=false
+```

--- a/configuration/telemetry.mdx
+++ b/configuration/telemetry.mdx
@@ -11,7 +11,7 @@ never shared with external entities, and you can opt-out at any time.
 
 ### What Kind of Data is Collected?
 
-- Flipt version (ie: v1.20.0)
+- Flipt version (ie: v1.21.0)
 - Database backend (ie: Postgres)
 - Cache backend (ie: Redis)
 - Authentication methods (ie: OIDC)
@@ -27,7 +27,7 @@ Here is an example of the telemetry data sent to Segment:
   "uuid": "1545d8a8-7a66-4d8d-a158-0a1c576c68a6",
   "lastTimestamp": "2023-04-25T01:01:51Z",
   "flipt": {
-    "version": "v1.20.1",
+    "version": "v1.21.1",
     "storage": {
       "database": "postgres",
       "cache": "redis"
@@ -39,8 +39,8 @@ Here is an example of the telemetry data sent to Segment:
 }
 ```
 
-You can view the full schema of the telemetry data on
-[GitHub](https://github.com/flipt-io/flipt/blob/05b85f6ec704d9eac850984c16d9bc3d15dbdb6c/internal/telemetry/telemetry.go#L26-L30).
+You can always view the full schema of the telemetry data and see how it is collected on
+[GitHub](https://github.com/flipt-io/flipt/blob/main/internal/telemetry/telemetry.go).
 
 ### How to Disable Telemetry
 

--- a/configuration/telemetry.mdx
+++ b/configuration/telemetry.mdx
@@ -23,25 +23,24 @@ Here is an example of the telemetry data sent to Segment:
 
 ```json
 {
-    "version": "1.1",
-    "uuid": "1545d8a8-7a66-4d8d-a158-0a1c576c68a6",
-    "lastTimestamp": "2023-04-25T01:01:51Z",
-    "flipt": {
-        "version": "v1.20.1",
-        "storage": {
-            "database": "postgres",
-            "cache": "redis"
-        },
-        "authentication": {
-            "methods": "oidc"
-        }
+  "version": "1.1",
+  "uuid": "1545d8a8-7a66-4d8d-a158-0a1c576c68a6",
+  "lastTimestamp": "2023-04-25T01:01:51Z",
+  "flipt": {
+    "version": "v1.20.1",
+    "storage": {
+      "database": "postgres",
+      "cache": "redis"
+    },
+    "authentication": {
+      "methods": "oidc"
     }
+  }
 }
 ```
 
 You can view the full schema of the telemetry data on
 [GitHub](https://github.com/flipt-io/flipt/blob/05b85f6ec704d9eac850984c16d9bc3d15dbdb6c/internal/telemetry/telemetry.go#L26-L30).
-
 
 ### How to Disable Telemetry
 
@@ -54,8 +53,14 @@ meta:
   telemetry_enabled: false
 ```
 
-#### Environment Variable
+#### Environment Variables
 
-```yaml
+```shell
 export FLIPT_TELEMETRY_ENABLED=false
+```
+
+As of [v1.21.0](https://github.com/flipt-io/flipt/releases/tag/v1.21.0), telemetry can also be disabled by setting the [DO_NOT_TRACK](https://consoledonottrack.com/) environment variable to `true` or `1`:
+
+```shell
+export DO_NOT_TRACK=true
 ```

--- a/mint.json
+++ b/mint.json
@@ -66,7 +66,8 @@
         "configuration/overview",
         "configuration/storage",
         "configuration/authentication",
-        "configuration/observability"
+        "configuration/observability",
+        "configuration/telemetry"
       ]
     },
     {


### PR DESCRIPTION
Docs for https://github.com/flipt-io/flipt/pull/1527

- splits out Telemetry and Observability into separate pages
- adds updated payload info

![CleanShot 2023-04-25 at 15 07 08](https://user-images.githubusercontent.com/209477/234378128-da545c46-ba08-4a95-938a-c6cf40f8ddc2.png)
