### PR TITLE
chore: reorg audit events section in config

### DIFF
--- a/configuration/overview.mdx
+++ b/configuration/overview.mdx
@@ -66,6 +66,20 @@ These properties are as follows:
 | server.cert_file  | Path to the certificate file (if protocol is set to https)     |         | v0.8.0 |
 | server.cert_key   | Path to the certificate key file (if protocol is set to https) |         | v0.8.0 |
 
+### Audit Events
+
+| Property                 | Description                                     | Default | Since   |
+| ------------------------ | ----------------------------------------------- | ------- | ------- |
+| audit.buffer.capacity    | Max capacity of buffer to send events to sinks  | 2       | v1.21.0 |
+| audit.buffer.flushPeriod | Duration to wait before sending events to sinks | 2m      | v1.21.0 |
+
+#### Audit Events: Log File
+
+| Property                | Description                                                              | Default | Since   |
+| ----------------------- | ------------------------------------------------------------------------ | ------- | ------- |
+| audit.sinks.log.enabled | Enable log file sink                                                     | false   | v1.21.0 |
+| audit.sinks.log.file    | File path to write audit events to. Required if log file sink is enabled |         | v1.21.0 |
+
 ### Tracing
 
 | Property         | Description                                | Default | Since   |
@@ -79,20 +93,6 @@ These properties are as follows:
 | ------------------- | ---------------------------------------- | --------- | ------- |
 | tracing.jaeger.host | The UDP host destination to report spans | localhost | v0.17.0 |
 | tracing.jaeger.port | The UDP port destination to report spans | 6831      | v0.17.0 |
-
-### Audit Events
-
-| Property                 | Description                                     | Default | Since   |
-| ------------------------ | ----------------------------------------------- | ------- | ------- |
-| audit.buffer.capacity    | Max capacity of buffer to send events to sinks  | 2       | v1.21.0 |
-| audit.buffer.flushPeriod | Duration to wait before sending events to sinks | 2m      | v1.21.0 |
-
-### Audit Events: Log File
-
-| Property                 | Description                                                               | Default | Since   |
-| ------------------------ | ------------------------------------------------------------------------- | ------- | ------- |
-| audit.sinks.log.enabled  | Enable log file sink                                                      | false   | v1.21.0 |
-| audit.sinks.log.file     | File path to write audit events to. Required if log file sink is enabled |         | v1.21.0 |
 
 #### Tracing: Zipkin
 


### PR DESCRIPTION
- audit events were intermingled with the `telemetry` section
- audit events: file section was as wrong 'level' heading wise

## Before

![CleanShot 2023-05-02 at 18 06 41](https://user-images.githubusercontent.com/209477/235796556-76f0d2ec-37e9-4af1-a1db-c50dd83a5fc6.png)

## After

![CleanShot 2023-05-02 at 18 07 09](https://user-images.githubusercontent.com/209477/235796564-e20b0b14-e500-4577-aba8-7b66d6efa6b5.png)

