### PR TITLE
feat: add docs for known locations flipt binary will check for configuration

### DIFF
--- a/installation.mdx
+++ b/installation.mdx
@@ -120,10 +120,10 @@ README, LICENSE, and CHANGELOG files.
 Run the Flipt binary with:
 
 ```console
-./flipt --config OPTIONAL_PATH_TO_YOUR_CONFIG
+./flipt [--config OPTIONAL_PATH_TO_YOUR_CONFIG]
 ```
 
-The flipt binary will check in a few different locations for server configuration (in order):
+As of version [v1.23](), the Flipt binary will check in a few different locations for server configuration (in order):
 
 1. `--config` flag as an override
 2. `$HOME/.flipt/config.yml`

--- a/installation.mdx
+++ b/installation.mdx
@@ -126,7 +126,7 @@ Run the Flipt binary with:
 As of version [v1.23](), the Flipt binary will check in a few different locations for server configuration (in order):
 
 1. `--config` flag as an override
-2. `$HOME/.flipt/config.yml`
+2. `{{ USER_CONFIG_DIR }}/flipt/config.yml` (the `USER_CONFIG_DIR` value is based on your architecture and specified [here](https://pkg.go.dev/os#UserConfigDir))
 3. `/etc/flipt/config/default.yml`
 
 See the [Configuration](/configuration) section for more details.

--- a/installation.mdx
+++ b/installation.mdx
@@ -120,8 +120,14 @@ README, LICENSE, and CHANGELOG files.
 Run the Flipt binary with:
 
 ```console
-./flipt --config PATH_TO_YOUR_CONFIG
+./flipt --config OPTIONAL_PATH_TO_YOUR_CONFIG
 ```
+
+The flipt binary will check in a few different locations for server configuration (in order):
+
+1. `--config` flag as an override
+2. `$HOME/.flipt/config.yml`
+3. `/etc/flipt/config/default.yml`
 
 See the [Configuration](/configuration) section for more details.
 

--- a/installation.mdx
+++ b/installation.mdx
@@ -123,7 +123,7 @@ Run the Flipt binary with:
 ./flipt [--config OPTIONAL_PATH_TO_YOUR_CONFIG]
 ```
 
-As of version [v1.23](), the Flipt binary will check in a few different locations for server configuration (in order):
+As of version [v1.23](https://github.com/flipt-io/flipt/releases/tag/v1.23.0), the Flipt binary will check in a few different locations for server configuration (in order):
 
 1. `--config` flag as an override
 2. `{{ USER_CONFIG_DIR }}/flipt/config.yml` (the `USER_CONFIG_DIR` value is based on your architecture and specified [here](https://pkg.go.dev/os#UserConfigDir))


### PR DESCRIPTION
Documentation for sourcing configuration for `flipt` binary.