### PR TITLE
chore(config): add a tip linking oidc auth to google login guide

### DIFF
--- a/configuration/authentication.mdx
+++ b/configuration/authentication.mdx
@@ -159,7 +159,8 @@ curl --request GET \
 #### Example: OIDC With Google
 
 <Tip>
-Checkout our new [Login with Google](/guides/login-with-google) guide for an in-depth look into configuring Google as an OIDC provider.
+  Checkout our new [Login with Google](/guides/login-with-google) guide for an
+  in-depth look into configuring Google as an OIDC provider.
 </Tip>
 
 Given we're running our instance of Flipt on the public internet at `https://flipt.myorg.com`.

--- a/configuration/authentication.mdx
+++ b/configuration/authentication.mdx
@@ -158,6 +158,10 @@ curl --request GET \
 
 #### Example: OIDC With Google
 
+<Tip>
+Checkout our new [Login with Google](/guides/login-with-google) guide for an in-depth look into configuring Google as an OIDC provider.
+</Tip>
+
 Given we're running our instance of Flipt on the public internet at `https://flipt.myorg.com`.
 
 Using Google as an example and the documentation linked above, we obtained the following credentials for a Google OAuth client:
@@ -186,7 +190,7 @@ authentication:
 ```
 
 <Note>
-  The callback URL for this provider would be
+  The redirect URL for this provider would be
   `https://flipt.myorg.com/auth/v1/method/oidc/google/callback`.
 </Note>
 


### PR DESCRIPTION
<img width="767" alt="Screenshot 2023-06-23 at 16 34 11" src="https://github.com/flipt-io/docs/assets/1253326/936a347a-aa2b-4e6a-b371-2ae8b9b5bd1f">

This is from a great suggestion by @jeremy-allocate here: https://github.com/flipt-io/flipt/discussions/1783#discussioncomment-6263322

Our OIDC configuration docs old example for Google OIDC now has a tip which leads them to the more in-depth guide.