### PR TITLE
feat(authentication): add documentation around exclusions in 1.24

### DIFF
--- a/authentication/overview.mdx
+++ b/authentication/overview.mdx
@@ -17,6 +17,7 @@ Once enabled, all routes beneath the following API prefixes will require a [clie
 - `/api/v1/`
 - `/auth/v1/`
 - `/meta`
+- `/evaluation/v1/`
 
 <Warning>
 The following URLs aren't protected by authentication:
@@ -30,6 +31,10 @@ We're exploring ways to support protecting these endpoints going forward.
 For now, we recommend excluding these API prefixes from your load-balancer.
 
 </Warning>
+
+Apart from `/auth/v1/` itself, the rest of the top-level API prefixes can be optionally excluded from authentication.
+Allowing for sections, such as the evaluations API, to be publicly accessible while still protecting the management and metadata APIs.
+Checkout the [Configuration: Authentication Exclusions](/configuration/authentication#exclusions) documentation for details.
 
 ## Client Tokens
 

--- a/authentication/overview.mdx
+++ b/authentication/overview.mdx
@@ -16,7 +16,7 @@ Once enabled, all routes beneath the following API prefixes will require a [clie
 
 - `/api/v1/`
 - `/auth/v1/`
-- `/meta`
+- `/meta/`
 - `/evaluation/v1/`
 
 <Warning>

--- a/configuration/authentication.mdx
+++ b/configuration/authentication.mdx
@@ -21,6 +21,39 @@ When authentication is set to `required`, the API will ensure valid credentials 
 
 See the [Authentication: Overview](/authentication/overview) documentation for more details on Flipt's API authentication handling.
 
+## Exclusions
+
+Exclusions allow you to disable authentication for sections of the API.
+The Flipt API is made of up of top-level API sections, each with its own unique prefix:
+
+- `/api/v1` is the core feature-flag state management section
+- `/meta` describes the configuration of the running Flipt instance
+- `/evaluation/v1` is the application facing flag state evaluation API
+
+Each of these API sections can be optionally ommitted from requiring authentication.
+A common usecase is to allow the evaluation API to be plublically accessible, while still requiring authenticated users for managing feature-flag configuration and state.
+
+By default, when authentication is configured as `required: true`, the effective configuration for the exclusions looks like this:
+
+```yaml config.yaml
+authentication:
+  required: true
+  exclude:
+    management: false
+    metadata: false
+    evaluation: false
+```
+
+This means every part of the Flipt API is required for authentication.
+However, taking the example from before, we could skip authentication for the evaluation section of the Flipt API like so:
+
+```yaml config.yaml
+authentication:
+  required: true
+  exclude:
+    evaluation: true
+```
+
 ## Session
 
 This section contains common properties for establishing browser sessions via a "session compatible" authentication method. Session-compatible methods enable support for login in the UI. The methods below state whether or not they're session compatible (e.g. [OIDC](#method-oidc) is session compatible).

--- a/configuration/authentication.mdx
+++ b/configuration/authentication.mdx
@@ -30,8 +30,8 @@ The Flipt API is made of up of top-level API sections, each with its own unique 
 - `/meta` describes the configuration of the running Flipt instance
 - `/evaluation/v1` is the application facing flag state evaluation API
 
-Each of these API sections can be optionally ommitted from requiring authentication.
-A common usecase is to allow the evaluation API to be plublically accessible, while still requiring authenticated users for managing feature-flag configuration and state.
+Each of these API sections can be optionally omitted from requiring authentication.
+A common use case is to allow the evaluation API to be publicly accessible, while still requiring authenticated users for managing feature-flag configuration and state.
 
 By default, when authentication is configured as `required: true`, the effective configuration for the exclusions looks like this:
 

--- a/configuration/authentication.mdx
+++ b/configuration/authentication.mdx
@@ -26,12 +26,12 @@ See the [Authentication: Overview](/authentication/overview) documentation for m
 Exclusions allow you to disable authentication for sections of the API.
 The Flipt API is made of up of top-level API sections, each with its own unique prefix:
 
-- `/api/v1` is the core feature-flag state management section
+- `/api/v1` is the core feature flag state management section
 - `/meta` describes the configuration of the running Flipt instance
 - `/evaluation/v1` is the application facing flag state evaluation API
 
 Each of these API sections can be optionally omitted from requiring authentication.
-A common use case is to allow the evaluation API to be publicly accessible, while still requiring authenticated users for managing feature-flag configuration and state.
+A common use case is to allow the evaluation API to be publicly accessible while still requiring authenticated users for managing feature-flag configuration and state.
 
 By default, when authentication is configured as `required: true`, the effective configuration for the exclusions looks like this:
 

--- a/configuration/overview.mdx
+++ b/configuration/overview.mdx
@@ -141,8 +141,8 @@ These properties are as follows:
 | ------------------------------------- | ------------------------------------------------------------- | ------- | ------- |
 | authentication.required               | Enable or disable authentication validation on requests       | false   | v1.15.0 |
 | authentication.exclude.management     | Exclude authentication for /api/v1 API prefix                 | false   | v1.24.0 |
-| authentication.exclude.metadata       | Exclude authentication for /evaluation/v1 API prefix          | false   | v1.24.0 |
-| authentication.exclude.evaluation     | Exclude authentication for /meta API prefix                   | false   | v1.24.0 |
+| authentication.exclude.metadata       | Exclude authentication for /meta API prefix                   | false   | v1.24.0 |
+| authentication.exclude.evaluation     | Exclude authentication for /evaluation/v1 API prefix          | false   | v1.24.0 |
 | authentication.session.domain         | Public domain on which Flipt instance is hosted               |         | v1.17.0 |
 | authentication.session.secure         | Configures the `Secure` property on created session cookies   | false   | v1.17.0 |
 | authentication.session.token_lifetime | Configures the lifetime of the session token (login duration) | 24h     | v1.17.0 |

--- a/configuration/overview.mdx
+++ b/configuration/overview.mdx
@@ -137,14 +137,17 @@ These properties are as follows:
 
 ### Authentication
 
-| Property                              | Description                                                   | Default | Since   |
-| ------------------------------------- | ------------------------------------------------------------- | ------- | ------- |
-| authentication.required               | Enable or disable authentication validation on requests       | false   | v1.15.0 |
-| authentication.session.domain         | Public domain on which Flipt instance is hosted               |         | v1.17.0 |
-| authentication.session.secure         | Configures the `Secure` property on created session cookies   | false   | v1.17.0 |
-| authentication.session.token_lifetime | Configures the lifetime of the session token (login duration) | 24h     | v1.17.0 |
-| authentication.session.state_lifetime | Configures the lifetime of state parameters during OAuth flow | 10m     | v1.17.0 |
-| authentication.session.csrf.key       | Secret credential used to sign CSRF prevention tokens         |         | v1.17.0 |
+| Property                              | Description                                                    | Default | Since   |
+| ------------------------------------- | -------------------------------------------------------------- | ------- | ------- |
+| authentication.required               | Enable or disable authentication validation on requests        | false   | v1.15.0 |
+| authentication.exclude.management     | Enable or disable authentication for /api/v1 API prefix        | false   | v1.24.0 |
+| authentication.exclude.metadata       | Enable or disable authentication for /evaluation/v1 API prefix | false   | v1.24.0 |
+| authentication.exclude.evaluation     | Enable or disable authentication for /meta API prefix          | false   | v1.24.0 |
+| authentication.session.domain         | Public domain on which Flipt instance is hosted                |         | v1.17.0 |
+| authentication.session.secure         | Configures the `Secure` property on created session cookies    | false   | v1.17.0 |
+| authentication.session.token_lifetime | Configures the lifetime of the session token (login duration)  | 24h     | v1.17.0 |
+| authentication.session.state_lifetime | Configures the lifetime of state parameters during OAuth flow  | 10m     | v1.17.0 |
+| authentication.session.csrf.key       | Secret credential used to sign CSRF prevention tokens          |         | v1.17.0 |
 
 #### Authentication Methods: Token
 

--- a/configuration/overview.mdx
+++ b/configuration/overview.mdx
@@ -137,17 +137,17 @@ These properties are as follows:
 
 ### Authentication
 
-| Property                              | Description                                                    | Default | Since   |
-| ------------------------------------- | -------------------------------------------------------------- | ------- | ------- |
-| authentication.required               | Enable or disable authentication validation on requests        | false   | v1.15.0 |
-| authentication.exclude.management     | Exclude authentication for /api/v1 API prefix                  | false   | v1.24.0 |
-| authentication.exclude.metadata       | Exclude authentication for /evaluation/v1 API prefix           | false   | v1.24.0 |
-| authentication.exclude.evaluation     | Exclude authentication for /meta API prefix                    | false   | v1.24.0 |
-| authentication.session.domain         | Public domain on which Flipt instance is hosted                |         | v1.17.0 |
-| authentication.session.secure         | Configures the `Secure` property on created session cookies    | false   | v1.17.0 |
-| authentication.session.token_lifetime | Configures the lifetime of the session token (login duration)  | 24h     | v1.17.0 |
-| authentication.session.state_lifetime | Configures the lifetime of state parameters during OAuth flow  | 10m     | v1.17.0 |
-| authentication.session.csrf.key       | Secret credential used to sign CSRF prevention tokens          |         | v1.17.0 |
+| Property                              | Description                                                   | Default | Since   |
+| ------------------------------------- | ------------------------------------------------------------- | ------- | ------- |
+| authentication.required               | Enable or disable authentication validation on requests       | false   | v1.15.0 |
+| authentication.exclude.management     | Exclude authentication for /api/v1 API prefix                 | false   | v1.24.0 |
+| authentication.exclude.metadata       | Exclude authentication for /evaluation/v1 API prefix          | false   | v1.24.0 |
+| authentication.exclude.evaluation     | Exclude authentication for /meta API prefix                   | false   | v1.24.0 |
+| authentication.session.domain         | Public domain on which Flipt instance is hosted               |         | v1.17.0 |
+| authentication.session.secure         | Configures the `Secure` property on created session cookies   | false   | v1.17.0 |
+| authentication.session.token_lifetime | Configures the lifetime of the session token (login duration) | 24h     | v1.17.0 |
+| authentication.session.state_lifetime | Configures the lifetime of state parameters during OAuth flow | 10m     | v1.17.0 |
+| authentication.session.csrf.key       | Secret credential used to sign CSRF prevention tokens         |         | v1.17.0 |
 
 #### Authentication Methods: Token
 

--- a/configuration/overview.mdx
+++ b/configuration/overview.mdx
@@ -140,9 +140,9 @@ These properties are as follows:
 | Property                              | Description                                                    | Default | Since   |
 | ------------------------------------- | -------------------------------------------------------------- | ------- | ------- |
 | authentication.required               | Enable or disable authentication validation on requests        | false   | v1.15.0 |
-| authentication.exclude.management     | Enable or disable authentication for /api/v1 API prefix        | false   | v1.24.0 |
-| authentication.exclude.metadata       | Enable or disable authentication for /evaluation/v1 API prefix | false   | v1.24.0 |
-| authentication.exclude.evaluation     | Enable or disable authentication for /meta API prefix          | false   | v1.24.0 |
+| authentication.exclude.management     | Exclude authentication for /api/v1 API prefix                  | false   | v1.24.0 |
+| authentication.exclude.metadata       | Exclude authentication for /evaluation/v1 API prefix           | false   | v1.24.0 |
+| authentication.exclude.evaluation     | Exclude authentication for /meta API prefix                    | false   | v1.24.0 |
 | authentication.session.domain         | Public domain on which Flipt instance is hosted                |         | v1.17.0 |
 | authentication.session.secure         | Configures the `Secure` property on created session cookies    | false   | v1.17.0 |
 | authentication.session.token_lifetime | Configures the lifetime of the session token (login duration)  | 24h     | v1.17.0 |


### PR DESCRIPTION
Fixes  FLI-506

Adds documentation around the new `authentication.exclude` configuration section.
This support disabling authentication on top-level sections of the API.

Blocked until 1.24 release