### PR TITLE
fix: path for evaluation exclusion

### DIFF
--- a/configuration/authentication.mdx
+++ b/configuration/authentication.mdx
@@ -28,7 +28,7 @@ The Flipt API is made of up of top-level API sections, each with its own unique 
 
 - `/api/v1` is the core feature flag state management section
 - `/meta` describes the configuration of the running Flipt instance
-- `/evaluation/v1` is the application facing flag state evaluation API
+- `/evaluate/v1` is the application facing flag state evaluation API
 
 Each of these API sections can be optionally omitted from requiring authentication.
 A common use case is to allow the evaluation API to be publicly accessible while still requiring authenticated users for managing feature-flag configuration and state.


### PR DESCRIPTION
`/evaluate/v1` is the evaluation API