### PR TITLE
fix: redirect from exp/fs-backends to storage

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -197,8 +197,8 @@
   ],
   "redirects": [
     {
-      "source": "experimental/filesystem-backends",
-      "destination": "configuration/storage"
+      "source": "/experimental/filesystem-backends",
+      "destination": "/configuration/storage"
     }
   ],
   "footerSocials": {


### PR DESCRIPTION
has to start with a `/` it seems: https://mintlify.com/docs/settings/broken-links#redirects