### PR TITLE
feat(overview): Added table entry for UI default_theme

### DIFF
--- a/configuration/overview.mdx
+++ b/configuration/overview.mdx
@@ -49,6 +49,7 @@ These properties are as follows:
 | Property               | Description                                                   | Default             | Since   |
 | ---------------------- | ------------------------------------------------------------- | ------------------- | ------- |
 | ui.enabled             | Enable Flipt UI                                               | true                |         |
+| ui.default_theme       | Sets the default UI theme for users                           | system              | v1.27.0 |
 | cors.enabled           | Enable CORS support                                           | false               | v0.7.0  |
 | cors.allowed_origins   | Sets Access-Control-Allow-Origin header on server             | "\*" (all domains)  | v0.7.0  |
 | meta.check_for_updates | Enable check for newer versions of Flipt on startup           | true                | v0.17.0 |


### PR DESCRIPTION
documentation changes for [#2062](https://github.com/flipt-io/flipt/pull/2062).

I may be presumptuous in adding the `Since` field as the next incremental release. I will keep this PR as a draft until the the feature has been released and we are certain what version it will exist in.