### PR TITLE
feat: add documentation for changes to import/export functionality

### DIFF
--- a/operations/import-export.mdx
+++ b/operations/import-export.mdx
@@ -53,9 +53,10 @@ flipt import --namespace production --create-namespace flipt.yaml
 <Note>
   In [v1.28.0](https://github.com/flipt-io/flipt/releases/tag/v1.28.0), we introduced some breaking changes to `import`.
 
-  You no longer have to use the `--namespace` or `--create-namespace` flags to import resources into a specific namespace.
+You no longer have to use the `--namespace` or `--create-namespace` flags to import resources into a specific namespace.
 
-  The namespaces are now inferred from the YAML documents themselves. If a namespace your document refers to does not exist in the database, it will be created.
+The namespaces are now inferred from the YAML documents themselves. If a namespace your document refers to does not exist in the database, it will be created.
+
 </Note>
 
 This command supports the `--drop` flag that will drop all of the data in your
@@ -106,9 +107,10 @@ flipt export --namespace production
 <Note>
   In [v1.28.0](https://github.com/flipt-io/flipt/releases/tag/v1.28.0), we have extended this functionality to support exporting state from multiple namespaces to a single YAML file.
 
-  The `--namespace` flag is now deprecated, and two new flags now exist.
+The `--namespace` flag is now deprecated, and two new flags now exist.
 
-  The `--namespaces` flag will accept a comma delimited list of namespaces from which you would like to export from.
+The `--namespaces` flag will accept a comma delimited list of namespaces from which you would like to export from.
 
-  The `--all-namespaces flag is a boolean flag which tells export to export all namespaces to the single file you specify, or to standard out by default.
+The `--all-namespaces flag is a boolean flag which tells export to export all namespaces to the single file you specify, or to standard out by default.
+
 </Note>

--- a/operations/import-export.mdx
+++ b/operations/import-export.mdx
@@ -104,9 +104,10 @@ flipt export --namespace production
 <Note>
   In [v1.28.0](https://github.com/flipt-io/flipt/releases/tag/v1.28.0), we have extended this functionality to support exporting state from multiple namespaces to a single YAML file.
 
-  The `--namespace` flag is now deprecated.
+The `--namespace` flag is now deprecated.
 
-  The `--namespaces` flag will accept a comma-delimited list of namespaces from which you would like to export from.
+The `--namespaces` flag will accept a comma-delimited list of namespaces from which you would like to export from.
 
-  The `--all-namespaces flag is a boolean flag that tells export to export all namespaces to the single file you specify, or to standard out by default.
+The `--all-namespaces flag is a boolean flag that tells export to export all namespaces to the single file you specify, or to standard out by default.
+
 </Note>

--- a/operations/import-export.mdx
+++ b/operations/import-export.mdx
@@ -106,9 +106,9 @@ flipt export --namespace production
 <Note>
   In [v1.28.0](https://github.com/flipt-io/flipt/releases/tag/v1.28.0), we have extended this functionality to support exporting state from multiple namespaces to a single YAML file.
 
-  The `--namespace` flag is now deprecated, and two new flags now exist.
+  The `--namespace` flag is now deprecated.
 
-  The `--namespaces` flag will accept a comma delimited list of namespaces from which you would like to export from.
+  The `--namespaces` flag will accept a comma-delimited list of namespaces from which you would like to export from.
 
-  The `--all-namespaces flag is a boolean flag which tells export to export all namespaces to the single file you specify, or to standard out by default.
+  The `--all-namespaces flag is a boolean flag that tells export to export all namespaces to the single file you specify, or to standard out by default.
 </Note>

--- a/operations/import-export.mdx
+++ b/operations/import-export.mdx
@@ -50,6 +50,14 @@ For convenience, you can supply `--create-namespace` in order for Flipt to autom
 flipt import --namespace production --create-namespace flipt.yaml
 ```
 
+<Note>
+  In [v1.28.0](https://github.com/flipt-io/flipt/releases/tag/v1.28.0), we introduced some breaking changes to `import`.
+
+  You no longer have to use the `--namespace` or `--create-namespace` flags to import resources into a specific namespace.
+
+  The namespaces are now inferred from the YAML documents themselves. If a namespace your document refers to does not exist in the database, it will be created.
+</Note>
+
 This command supports the `--drop` flag that will drop all of the data in your
 Flipt database tables before importing. This is to ensure that no data
 collisions occur during the import.
@@ -79,7 +87,6 @@ flags:
     name: Blue
   - key: green
     name: Green
-
 ```
 
 You can also export to a file using the `-o filename` or `--output filename`
@@ -95,3 +102,13 @@ Use the flag `--namespace` to export from a different namespace.
 ```yaml
 flipt export --namespace production
 ```
+
+<Note>
+  In [v1.28.0](https://github.com/flipt-io/flipt/releases/tag/v1.28.0), we have extended this functionality to support exporting state from multiple namespaces to a single YAML file.
+
+  The `--namespace` flag is now deprecated, and two new flags now exist.
+
+  The `--namespaces` flag will accept a comma delimited list of namespaces from which you would like to export from.
+
+  The `--all-namespaces flag is a boolean flag which tells export to export all namespaces to the single file you specify, or to standard out by default.
+</Note>


### PR DESCRIPTION
Documentation for the new changes to the import/export functionality.

This change talks about the breaking changes in mdx Notes. The reason being that the previously existing documentation for import and export will still be relevant for some time due to people not being updated to the latest Flipt.

Completes FLI-617