### PR TITLE
feat: add CLI docs

### DIFF
--- a/.vale/styles/Flipt/spelling-exceptions.txt
+++ b/.vale/styles/Flipt/spelling-exceptions.txt
@@ -5,6 +5,7 @@ boolean
 caddy
 codeowners
 codespaces
+darwin
 datetime
 declaratively
 deletable
@@ -14,7 +15,9 @@ dev
 dex
 flipt
 flipt's
+Gitlab
 grafana
+hostname
 http
 httplug
 https
@@ -28,6 +31,7 @@ mintlify
 namespace
 namespaces
 nginx
+ngrok
 oauth
 oidc
 okta
@@ -37,11 +41,13 @@ PGBouncer
 postgres
 protobuf
 protoc
+Quicksort
 redis
 regexes
 rflipt
 rollout
 rollouts
+SCMs
 sdk
 sdks
 sqlite
@@ -50,8 +56,3 @@ uncomment
 URIs
 yaml
 zipkin
-Quicksort
-SCMs
-Gitlab
-ngrok
-hostname

--- a/cli/commands/config/edit.mdx
+++ b/cli/commands/config/edit.mdx
@@ -1,0 +1,20 @@
+---
+title: "config edit"
+description: "Edit Flipt configuration"
+---
+
+```
+flipt config edit [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for edit
+```
+
+### Inherited Options
+
+```
+      --config string   path to config file
+```

--- a/cli/commands/config/edit.mdx
+++ b/cli/commands/config/edit.mdx
@@ -18,3 +18,7 @@ flipt config edit [flags]
 ```
       --config string   path to config file
 ```
+
+### More Info
+
+See the [configuration](/configuration) section of the documentation for more information.

--- a/cli/commands/config/init.mdx
+++ b/cli/commands/config/init.mdx
@@ -19,3 +19,7 @@ flipt config init [flags]
 ```
       --config string   path to config file
 ```
+
+### More Info
+
+See the [configuration](/configuration) section of the documentation for more information.

--- a/cli/commands/config/init.mdx
+++ b/cli/commands/config/init.mdx
@@ -1,0 +1,21 @@
+---
+title: "config init"
+description: "Initialize Flipt configuration"
+---
+
+```
+flipt config init [flags]
+```
+
+### Options
+
+```
+  -y, --force   Overwrite existing configuration file
+  -h, --help    help for init
+```
+
+### Inherited Options
+
+```
+      --config string   path to config file
+```

--- a/cli/commands/export.mdx
+++ b/cli/commands/export.mdx
@@ -18,3 +18,7 @@ flipt export [flags]
   -o, --output string       export to filename (default STDOUT)
   -t, --token string        client token used to authenticate access to remote Flipt instance when exporting.
 ```
+
+### More Info
+
+See the [import/export](/operations/import-export) section of the documentation for more information.

--- a/cli/commands/export.mdx
+++ b/cli/commands/export.mdx
@@ -1,0 +1,20 @@
+---
+title: "export"
+description: "Export Flipt data to file/stdout"
+---
+
+```
+flipt export [flags]
+```
+
+### Options
+
+```
+  -a, --address string      address of remote Flipt instance to export from (defaults to direct DB export if not supplied)
+      --all-namespaces      export all namespaces. (mutually exclusive with --namespaces)
+      --config string       path to config file
+  -h, --help                help for export
+      --namespaces string   comma-delimited list of namespaces to export from. (mutually exclusive with --all-namespaces) (default "default")
+  -o, --output string       export to filename (default STDOUT)
+  -t, --token string        client token used to authenticate access to remote Flipt instance when exporting.
+```

--- a/cli/commands/import.mdx
+++ b/cli/commands/import.mdx
@@ -1,0 +1,19 @@
+---
+title: "import"
+description: "Import Flipt data from file/stdin"
+---
+
+```
+flipt import [flags]
+```
+
+### Options
+
+```
+  -a, --address string   address of remote Flipt instance to import into (defaults to direct DB import if not supplied)
+      --config string    path to config file
+      --drop             drop database before import
+  -h, --help             help for import
+      --stdin            import from STDIN
+  -t, --token string     client token used to authenticate access to remote Flipt instance when importing.
+```

--- a/cli/commands/import.mdx
+++ b/cli/commands/import.mdx
@@ -17,3 +17,7 @@ flipt import [flags]
       --stdin            import from STDIN
   -t, --token string     client token used to authenticate access to remote Flipt instance when importing.
 ```
+
+### More Info
+
+See the [import/export](/operations/import-export) section of the documentation for more information.

--- a/cli/commands/migrate.mdx
+++ b/cli/commands/migrate.mdx
@@ -1,0 +1,15 @@
+---
+title: "migrate"
+description: "Run pending database migrations"
+---
+
+```
+flipt migrate [flags]
+```
+
+### Options
+
+```
+      --config string   path to config file
+  -h, --help            help for migrate
+```

--- a/cli/commands/migrate.mdx
+++ b/cli/commands/migrate.mdx
@@ -13,3 +13,7 @@ flipt migrate [flags]
       --config string   path to config file
   -h, --help            help for migrate
 ```
+
+### More Info
+
+See the [migrations](/configuration/storage#migrations) section of the documentation for more information.

--- a/cli/commands/validate.mdx
+++ b/cli/commands/validate.mdx
@@ -1,0 +1,16 @@
+---
+title: "validate"
+description: "Validate Flipt flag state (.yaml, .yml) files"
+---
+
+```
+flipt validate [flags]
+```
+
+### Options
+
+```
+  -F, --format string         output format: json, text (default "text")
+  -h, --help                  help for validate
+      --issue-exit-code int   Exit code to use when issues are found (default 1)
+```

--- a/cli/commands/validate.mdx
+++ b/cli/commands/validate.mdx
@@ -14,3 +14,7 @@ flipt validate [flags]
   -h, --help                  help for validate
       --issue-exit-code int   Exit code to use when issues are found (default 1)
 ```
+
+### More Info
+
+See the [flag state](/configuration/storage#flag-state-configuration) section of the documentation for more information.

--- a/cli/overview.mdx
+++ b/cli/overview.mdx
@@ -3,7 +3,7 @@ title: "Overview"
 description: "Overview of the flipt CLI"
 ---
 
-The flipt CLI is a command line interface for managing Flipt. It's useful for managing your Flipt instance, including configuration, migrations, and more.
+The `flipt` CLI is a command line interface for managing Flipt. It's useful for configuring your Flipt instance, running migrations, validating `.features.yml` files, and more.
 
 You can use it in various environments, including your local machine, CI/CD, and more.
 

--- a/cli/overview.mdx
+++ b/cli/overview.mdx
@@ -1,0 +1,44 @@
+---
+title: "Overview"
+description: "Overview of the flipt CLI"
+---
+
+The flipt CLI is a command line interface for managing Flipt. It's useful for managing your Flipt instance, including configuration, migrations, and more.
+
+You can use it in various environments, including your local machine, CI/CD, and more.
+
+### Installation
+
+<CodeGroup>
+```console Homebrew
+brew install flipt-io/brew/flipt
+```
+
+```console Binary
+curl -fsSL https://github.com/flipt-io/flipt/raw/main/install.sh | bash
+```
+
+</CodeGroup>
+
+### Usage
+
+```
+flipt <command> <subcommand> [flags]
+```
+
+`flipt` with no arguments will run the Flipt server. It will look for a configuration file as described in the [configuration](/configuration/overview#configuration-file) documentation. You can specify a different configuration file with the `--config` flag.
+
+### Examples
+
+```
+$ flipt
+$ flipt config init
+$ flipt --config /path/to/config.yml migrate
+```
+
+### Options
+
+```
+      --config string   path to config file
+  -h, --help            help for flipt
+```

--- a/configuration/overview.mdx
+++ b/configuration/overview.mdx
@@ -3,7 +3,7 @@ title: Overview
 description: This document describes how to configure the Flipt server.
 ---
 
-`Flipt` server can be configured in two ways.
+Flipt server can be configured in two ways.
 
 Configuration precedence is as follows:
 
@@ -18,29 +18,27 @@ The default way that Flipt is configured is with the use of a configuration file
 This file is read when Flipt starts up and configures several important
 properties for the server.
 
-As of version [v1.23](https://github.com/flipt-io/flipt/releases/tag/v1.23.0), the server will check in a few different locations for server configuration (in order):
+<Tip>
+  You can generate a default configuration file by running `flipt config init`
+  as of v1.28.0. See the [CLI](/cli) documentation for more information.
+</Tip>
+
+The server will check in a few different locations for server configuration (in order):
 
 1. `--config` flag as an override
 2. `{{ USER_CONFIG_DIR }}/flipt/config.yml` (the `USER_CONFIG_DIR` value is based on your architecture and specified in the [Go documentation](https://pkg.go.dev/os#UserConfigDir))
 3. `/etc/flipt/config/default.yml`
 
-<Tip>
+<Note>
   We provide both a [JSON
   schema](https://raw.githubusercontent.com/flipt-io/flipt/main/config/flipt.schema.json)
   and a [Cue
   schema](https://raw.githubusercontent.com/flipt-io/flipt/main/config/flipt.schema.cue)
   that you can use to validate your configuration file and it's properties.
-</Tip>
+</Note>
 
 You can edit any of these properties to your liking, and on restart Flipt will
 pick up the new changes.
-
-<Note>
-  These defaults are commented out in
-  [default.yml](https://github.com/flipt-io/flipt/blob/main/config/default.yml)
-  to give you an idea of what they are. To change them you'll first need to
-  uncomment them.
-</Note>
 
 These properties are as follows:
 

--- a/mint.json
+++ b/mint.json
@@ -104,6 +104,28 @@
       ]
     },
     {
+      "group": "CLI",
+      "pages": [
+        "cli/overview",
+        {
+          "group": "Commands",
+          "pages":[
+            {
+              "group": "config",
+              "pages":[
+                "cli/commands/config/init",
+                "cli/commands/config/edit"
+              ]
+            },
+            "cli/commands/export",
+            "cli/commands/import",
+            "cli/commands/migrate",
+            "cli/commands/validate"
+          ]
+        }
+      ]
+    },
+    {
       "group": "Authentication",
       "pages": [
         "authentication/overview",


### PR DESCRIPTION
Fixes: FLI-608

Adds CLI docs, pending new CLI commands `config init` and `config edit` in the next release

![CleanShot 2023-09-28 at 15 29 15](https://github.com/flipt-io/docs/assets/209477/35feec08-fce9-453a-a278-dce0df2df7f8)
