### PR TITLE
chore: move openfeature go link to openfeature-contrib repo

### DIFF
--- a/integration/openfeature.mdx
+++ b/integration/openfeature.mdx
@@ -34,7 +34,7 @@ We currently provide the following OpenFeature providers:
 
 <CardGroup cols={2}>
   <Card
-    href="https://github.com/flipt-io/flipt-openfeature-provider-go"
+    href="https://github.com/open-feature/go-sdk-contrib/tree/main/providers/flipt"
     title="Go"
     icon="golang"
     color="#00add8"


### PR DESCRIPTION
We have moved our openfeature-go SDK to the openfeature-go-contrib repo (https://github.com/open-feature/go-sdk-contrib)

https://github.com/flipt-io/flipt-openfeature-provider-go

This updates our docs to point to the new location