### PR TITLE
fix(guides): ensure all example configuration is valid and clear/copyable

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 openapi.yaml
 mint.json
+guides/get-going-with-gitops.mdx

--- a/guides/get-going-with-gitops.mdx
+++ b/guides/get-going-with-gitops.mdx
@@ -142,7 +142,7 @@ func (s *Server) ListWords(w http.ResponseWriter, r *http.Request) {
     return
   }
 }
-````
+```
 
 </CodeGroup>
 

--- a/guides/get-going-with-gitops.mdx
+++ b/guides/get-going-with-gitops.mdx
@@ -84,7 +84,8 @@ Instead of calling `bubblesort` directly, we're going to use the [Flipt Go SDK](
 This flag is going to be a **boolean** type flag, and so we use the `sdk.Evaluation().Boolean()` call to evaluate the `enabled` property of our flag.
 We provide this evaluation call with a request containing the flags key, an entity ID and a context map.
 
-```diff
+<CodeGroup>
+```diff diff.go
  func (s *Server) ListWords(w http.ResponseWriter, r *http.Request) {
    words, err := getWords(r.Context())
    if err != nil {
@@ -113,6 +114,37 @@ We provide this evaluation call with a request containing the flags key, an enti
    }
  }
 ```
+
+```go pkg/server/words.go
+func (s *Server) ListWords(w http.ResponseWriter, r *http.Request) {
+  words, err := getWords(r.Context())
+  if err != nil {
+    http.Error(w, err.Error(), http.StatusInternalServerError)
+    return
+  }
+
+  bubbleSort(words)
+  flag, err := s.flipt.Evaluation().Boolean(r.Context(), &evaluation.EvaluationRequest{
+    FlagKey: "use-quicksort-algorithm",
+    EntityId: getUser(r.Context()),
+    Context: map[string]string{
+      "organization": getOrganization(r.Context()),
+    },
+  })
+
+  if flag.Enabled {
+    quicksort(words)
+  } else {
+    bubblesort(words)
+  }
+
+  if err := json.NewEncoder(w).Encode(words); err != nil {
+    http.Error(w, err.Error(), http.StatusInternalServerError)
+    return
+  }
+}
+```
+</CodeGroup>
 
 The entity ID used here is going to be an identifier for the requests authenticated user. This is returned by the call to `getUser(r.Context())`.
 
@@ -164,9 +196,10 @@ This flag will be a _boolean_ type flag and be in a disabled (`enabled = false`)
 version: "1.2"
 namespace: default
 flags:
-  - key: use-quicksort-algorithm
-    type: BOOLEAN_FLAG_TYPE
-    enabled: false
+- key: use-quicksort-algorithm
+  name: Use Quicksort Algorithm
+  type: BOOLEAN_FLAG_TYPE
+  enabled: false
 ```
 
 ### Running Flipt Locally
@@ -263,11 +296,14 @@ git checkout -b enable-flag-for-internal-organization
 
 We open the `features.yml` file and update the definition with a new segment and add a rollout rule on our flag which returns `enable = true` when the request matches our new segment.
 
-```diff features.yml
+<CodeGroup>
+
+```diff features.diff
  version: "1.2"
  namespace: default
  flags:
  - key: use-quicksort-algorithm
+   name: Use Quicksort Algorithm
    type: BOOLEAN_FLAG_TYPE
    enabled: false
 +  rollouts:
@@ -276,12 +312,39 @@ We open the `features.yml` file and update the definition with a new segment and
 +      value: true
 +segments:
 +- key: internal-users
++  name: Internal Users
++  match_type: ANY_MATCH_TYPE
 +  constraints:
 +  - property: organization
-+    operatior: eq
++    operator: eq
 +    value: internal
 +    type: STRING_COMPARISON_TYPE
 ```
+
+```yaml features.yml
+version: "1.2"
+namespace: default
+flags:
+- key: use-quicksort-algorithm
+  name: Use Quicksort Algorithm
+  type: BOOLEAN_FLAG_TYPE
+  enabled: false
+  rollouts:
+  - segment:
+      key: internal-users
+      value: true
+segments:
+- key: internal-users
+  name: Internal Users
+  match_type: ANY_MATCH_TYPE
+  constraints:
+  - property: organization
+    operator: eq
+    value: internal
+    type: STRING_COMPARISON_TYPE
+```
+
+</CodeGroup>
 
 Breaking this change down we've got:
 
@@ -290,12 +353,14 @@ Breaking this change down we've got:
 ```yaml features.yml
 # ...
 segments:
-  - key: internal-users
-    constraints:
-      - property: organization
-        operatior: eq
-        value: internal
-        type: STRING_COMPARISON_TYPE
+- key: internal-users
+  name: Internal Users
+  match_type: ANY_MATCH_TYPE
+  constraints:
+  - property: organization
+    operator: eq
+    value: internal
+    type: STRING_COMPARISON_TYPE
 ```
 
 This [segment](/concepts#segments) definition matches any evaluation request where there exists a key `organization` on the context, with a value `internal`.
@@ -308,12 +373,12 @@ Now, when the user happens to be associated with the `internal` organization, it
 
 ```yaml features.yml
 flags:
-  - key: user-quicksort-algorithm
-    # ...
-    rollouts:
-      - segment:
-          key: internal-users
-          value: true
+- key: use-quicksort-algorithm
+  # ...
+  rollouts:
+  - segment:
+      key: internal-users
+      value: true
 ```
 
 Finally, we add a [rollout rule](/concepts#rollouts) to our boolean flag.
@@ -379,11 +444,13 @@ git checkout -b enable-flag-for-20-percent
 
 Then we're going to edit `features.yml` and add a threshold percentage rule.
 
-```diff features.yml
+<CodeGroup>
+```diff features.diff
  version: "1.2"
  namespace: default
  flags:
  - key: use-quicksort-algorithm
+   name: Use Quicksort Algorithm
    type: BOOLEAN_FLAG_TYPE
    enabled: false
    rollouts:
@@ -395,12 +462,41 @@ Then we're going to edit `features.yml` and add a threshold percentage rule.
 +      value: true
  segments:
  - key: internal-users
+   name: Internal Users
+   match_type: ANY_MATCH_TYPE
    constraints:
    - property: organization
-     operatior: eq
+     operator: eq
      value: internal
      type: STRING_COMPARISON_TYPE
 ```
+
+```yaml features.yaml
+version: "1.2"
+namespace: default
+flags:
+- key: use-quicksort-algorithm
+  name: Use Quicksort Algorithm
+  type: BOOLEAN_FLAG_TYPE
+  enabled: false
+  rollouts:
+  - segment:
+      key: internal-users
+      value: true
+  - threshold:
+      percentage: 20
+      value: true
+segments:
+- key: internal-users
+  name: Internal Users
+  match_type: ANY_MATCH_TYPE
+  constraints:
+  - property: organization
+    operator: eq
+    value: internal
+    type: STRING_COMPARISON_TYPE
+```
+</CodeGroup>
 
 Again, breaking this change down:
 
@@ -457,9 +553,10 @@ Once we get to the stage of enabling the flag for 100% of users, we can either s
 version: "1.2"
 namespace: default
 flags:
-  - key: use-quicksort-algorithm
-    type: BOOLEAN_FLAG_TYPE
-    enabled: true
+- key: use-quicksort-algorithm
+  name: Use Quicksort Algorithm
+  type: BOOLEAN_FLAG_TYPE
+  enabled: true
 ```
 
 Beyond this, we can further close the loop by removing the feature flag call from our application code and simply use the new `quicksort` function.

--- a/guides/get-going-with-gitops.mdx
+++ b/guides/get-going-with-gitops.mdx
@@ -93,27 +93,29 @@ We provide this evaluation call with a request containing the flags key, an enti
      return
    }
 
--  bubbleSort(words)
-+  flag, err := s.flipt.Evaluation().Boolean(r.Context(), &evaluation.EvaluationRequest{
-+    FlagKey: "use-quicksort-algorithm",
-+    EntityId: getUser(r.Context()),
-+    Context: map[string]string{
-+      "organization": getOrganization(r.Context()),
-+    },
-+  })
-+
-+  if flag.Enabled {
-+    quicksort(words)
-+  } else {
-+    bubblesort(words)
-+  }
+- bubbleSort(words)
 
-   if err := json.NewEncoder(w).Encode(words); err != nil {
-     http.Error(w, err.Error(), http.StatusInternalServerError)
-     return
-   }
- }
-```
+* flag, err := s.flipt.Evaluation().Boolean(r.Context(), &evaluation.EvaluationRequest{
+* FlagKey: "use-quicksort-algorithm",
+* EntityId: getUser(r.Context()),
+* Context: map[string]string{
+*      "organization": getOrganization(r.Context()),
+* },
+* })
+*
+* if flag.Enabled {
+* quicksort(words)
+* } else {
+* bubblesort(words)
+* }
+
+  if err := json.NewEncoder(w).Encode(words); err != nil {
+  http.Error(w, err.Error(), http.StatusInternalServerError)
+  return
+  }
+  }
+
+````
 
 ```go pkg/server/words.go
 func (s *Server) ListWords(w http.ResponseWriter, r *http.Request) {
@@ -143,7 +145,8 @@ func (s *Server) ListWords(w http.ResponseWriter, r *http.Request) {
     return
   }
 }
-```
+````
+
 </CodeGroup>
 
 The entity ID used here is going to be an identifier for the requests authenticated user. This is returned by the call to `getUser(r.Context())`.
@@ -196,10 +199,10 @@ This flag will be a _boolean_ type flag and be in a disabled (`enabled = false`)
 version: "1.2"
 namespace: default
 flags:
-- key: use-quicksort-algorithm
-  name: Use Quicksort Algorithm
-  type: BOOLEAN_FLAG_TYPE
-  enabled: false
+  - key: use-quicksort-algorithm
+    name: Use Quicksort Algorithm
+    type: BOOLEAN_FLAG_TYPE
+    enabled: false
 ```
 
 ### Running Flipt Locally
@@ -325,23 +328,23 @@ We open the `features.yml` file and update the definition with a new segment and
 version: "1.2"
 namespace: default
 flags:
-- key: use-quicksort-algorithm
-  name: Use Quicksort Algorithm
-  type: BOOLEAN_FLAG_TYPE
-  enabled: false
-  rollouts:
-  - segment:
-      key: internal-users
-      value: true
+  - key: use-quicksort-algorithm
+    name: Use Quicksort Algorithm
+    type: BOOLEAN_FLAG_TYPE
+    enabled: false
+    rollouts:
+      - segment:
+          key: internal-users
+          value: true
 segments:
-- key: internal-users
-  name: Internal Users
-  match_type: ANY_MATCH_TYPE
-  constraints:
-  - property: organization
-    operator: eq
-    value: internal
-    type: STRING_COMPARISON_TYPE
+  - key: internal-users
+    name: Internal Users
+    match_type: ANY_MATCH_TYPE
+    constraints:
+      - property: organization
+        operator: eq
+        value: internal
+        type: STRING_COMPARISON_TYPE
 ```
 
 </CodeGroup>
@@ -353,14 +356,14 @@ Breaking this change down we've got:
 ```yaml features.yml
 # ...
 segments:
-- key: internal-users
-  name: Internal Users
-  match_type: ANY_MATCH_TYPE
-  constraints:
-  - property: organization
-    operator: eq
-    value: internal
-    type: STRING_COMPARISON_TYPE
+  - key: internal-users
+    name: Internal Users
+    match_type: ANY_MATCH_TYPE
+    constraints:
+      - property: organization
+        operator: eq
+        value: internal
+        type: STRING_COMPARISON_TYPE
 ```
 
 This [segment](/concepts#segments) definition matches any evaluation request where there exists a key `organization` on the context, with a value `internal`.
@@ -373,12 +376,12 @@ Now, when the user happens to be associated with the `internal` organization, it
 
 ```yaml features.yml
 flags:
-- key: use-quicksort-algorithm
-  # ...
-  rollouts:
-  - segment:
-      key: internal-users
-      value: true
+  - key: use-quicksort-algorithm
+    # ...
+    rollouts:
+      - segment:
+          key: internal-users
+          value: true
 ```
 
 Finally, we add a [rollout rule](/concepts#rollouts) to our boolean flag.
@@ -475,27 +478,28 @@ Then we're going to edit `features.yml` and add a threshold percentage rule.
 version: "1.2"
 namespace: default
 flags:
-- key: use-quicksort-algorithm
-  name: Use Quicksort Algorithm
-  type: BOOLEAN_FLAG_TYPE
-  enabled: false
-  rollouts:
-  - segment:
-      key: internal-users
-      value: true
-  - threshold:
-      percentage: 20
-      value: true
+  - key: use-quicksort-algorithm
+    name: Use Quicksort Algorithm
+    type: BOOLEAN_FLAG_TYPE
+    enabled: false
+    rollouts:
+      - segment:
+          key: internal-users
+          value: true
+      - threshold:
+          percentage: 20
+          value: true
 segments:
-- key: internal-users
-  name: Internal Users
-  match_type: ANY_MATCH_TYPE
-  constraints:
-  - property: organization
-    operator: eq
-    value: internal
-    type: STRING_COMPARISON_TYPE
+  - key: internal-users
+    name: Internal Users
+    match_type: ANY_MATCH_TYPE
+    constraints:
+      - property: organization
+        operator: eq
+        value: internal
+        type: STRING_COMPARISON_TYPE
 ```
+
 </CodeGroup>
 
 Again, breaking this change down:
@@ -553,10 +557,10 @@ Once we get to the stage of enabling the flag for 100% of users, we can either s
 version: "1.2"
 namespace: default
 flags:
-- key: use-quicksort-algorithm
-  name: Use Quicksort Algorithm
-  type: BOOLEAN_FLAG_TYPE
-  enabled: true
+  - key: use-quicksort-algorithm
+    name: Use Quicksort Algorithm
+    type: BOOLEAN_FLAG_TYPE
+    enabled: true
 ```
 
 Beyond this, we can further close the loop by removing the feature flag call from our application code and simply use the new `quicksort` function.

--- a/guides/get-going-with-gitops.mdx
+++ b/guides/get-going-with-gitops.mdx
@@ -143,7 +143,6 @@ func (s *Server) ListWords(w http.ResponseWriter, r *http.Request) {
   }
 }
 ```
-
 </CodeGroup>
 
 The entity ID used here is going to be an identifier for the requests authenticated user. This is returned by the call to `getUser(r.Context())`.

--- a/guides/get-going-with-gitops.mdx
+++ b/guides/get-going-with-gitops.mdx
@@ -123,7 +123,6 @@ func (s *Server) ListWords(w http.ResponseWriter, r *http.Request) {
     return
   }
 
-  bubbleSort(words)
   flag, err := s.flipt.Evaluation().Boolean(r.Context(), &evaluation.EvaluationRequest{
     FlagKey: "use-quicksort-algorithm",
     EntityId: getUser(r.Context()),

--- a/guides/get-going-with-gitops.mdx
+++ b/guides/get-going-with-gitops.mdx
@@ -195,10 +195,10 @@ This flag will be a _boolean_ type flag and be in a disabled (`enabled = false`)
 version: "1.2"
 namespace: default
 flags:
-  - key: use-quicksort-algorithm
-    name: Use Quicksort Algorithm
-    type: BOOLEAN_FLAG_TYPE
-    enabled: false
+- key: use-quicksort-algorithm
+  name: Use Quicksort Algorithm
+  type: BOOLEAN_FLAG_TYPE
+  enabled: false
 ```
 
 ### Running Flipt Locally
@@ -324,23 +324,23 @@ We open the `features.yml` file and update the definition with a new segment and
 version: "1.2"
 namespace: default
 flags:
-  - key: use-quicksort-algorithm
-    name: Use Quicksort Algorithm
-    type: BOOLEAN_FLAG_TYPE
-    enabled: false
-    rollouts:
-      - segment:
-          key: internal-users
-          value: true
+- key: use-quicksort-algorithm
+  name: Use Quicksort Algorithm
+  type: BOOLEAN_FLAG_TYPE
+  enabled: false
+  rollouts:
+  - segment:
+      key: internal-users
+      value: true
 segments:
-  - key: internal-users
-    name: Internal Users
-    match_type: ANY_MATCH_TYPE
-    constraints:
-      - property: organization
-        operator: eq
-        value: internal
-        type: STRING_COMPARISON_TYPE
+- key: internal-users
+  name: Internal Users
+  match_type: ANY_MATCH_TYPE
+  constraints:
+  - property: organization
+    operator: eq
+    value: internal
+    type: STRING_COMPARISON_TYPE
 ```
 
 </CodeGroup>
@@ -352,14 +352,14 @@ Breaking this change down we've got:
 ```yaml features.yml
 # ...
 segments:
-  - key: internal-users
-    name: Internal Users
-    match_type: ANY_MATCH_TYPE
-    constraints:
-      - property: organization
-        operator: eq
-        value: internal
-        type: STRING_COMPARISON_TYPE
+- key: internal-users
+  name: Internal Users
+  match_type: ANY_MATCH_TYPE
+  constraints:
+  - property: organization
+    operator: eq
+    value: internal
+    type: STRING_COMPARISON_TYPE
 ```
 
 This [segment](/concepts#segments) definition matches any evaluation request where there exists a key `organization` on the context, with a value `internal`.
@@ -372,12 +372,12 @@ Now, when the user happens to be associated with the `internal` organization, it
 
 ```yaml features.yml
 flags:
-  - key: use-quicksort-algorithm
-    # ...
-    rollouts:
-      - segment:
-          key: internal-users
-          value: true
+- key: use-quicksort-algorithm
+  # ...
+  rollouts:
+  - segment:
+      key: internal-users
+      value: true
 ```
 
 Finally, we add a [rollout rule](/concepts#rollouts) to our boolean flag.
@@ -474,26 +474,26 @@ Then we're going to edit `features.yml` and add a threshold percentage rule.
 version: "1.2"
 namespace: default
 flags:
-  - key: use-quicksort-algorithm
-    name: Use Quicksort Algorithm
-    type: BOOLEAN_FLAG_TYPE
-    enabled: false
-    rollouts:
-      - segment:
-          key: internal-users
-          value: true
-      - threshold:
-          percentage: 20
-          value: true
+- key: use-quicksort-algorithm
+  name: Use Quicksort Algorithm
+  type: BOOLEAN_FLAG_TYPE
+  enabled: false
+  rollouts:
+  - segment:
+      key: internal-users
+      value: true
+  - threshold:
+      percentage: 20
+      value: true
 segments:
-  - key: internal-users
-    name: Internal Users
-    match_type: ANY_MATCH_TYPE
-    constraints:
-      - property: organization
-        operator: eq
-        value: internal
-        type: STRING_COMPARISON_TYPE
+- key: internal-users
+  name: Internal Users
+  match_type: ANY_MATCH_TYPE
+  constraints:
+  - property: organization
+    operator: eq
+    value: internal
+    type: STRING_COMPARISON_TYPE
 ```
 
 </CodeGroup>
@@ -514,12 +514,12 @@ If no rules match, then the flags top-level `enabled` property is used as the fi
 flags:
 - key: use-quicksort-algorithm
 # ...
-  - segment:
-      key: internal-users
-      value: true
-  - threshold:
-      percentage: 20
-      value: true
+- segment:
+    key: internal-users
+    value: true
+- threshold:
+    percentage: 20
+    value: true
 ```
 
 This threshold percentage is set to `20`, meaning roughly `20%` of entity IDs will match and cause the flag to return `enabled = true`.
@@ -553,10 +553,10 @@ Once we get to the stage of enabling the flag for 100% of users, we can either s
 version: "1.2"
 namespace: default
 flags:
-  - key: use-quicksort-algorithm
-    name: Use Quicksort Algorithm
-    type: BOOLEAN_FLAG_TYPE
-    enabled: true
+- key: use-quicksort-algorithm
+  name: Use Quicksort Algorithm
+  type: BOOLEAN_FLAG_TYPE
+  enabled: true
 ```
 
 Beyond this, we can further close the loop by removing the feature flag call from our application code and simply use the new `quicksort` function.

--- a/guides/get-going-with-gitops.mdx
+++ b/guides/get-going-with-gitops.mdx
@@ -94,28 +94,26 @@ We provide this evaluation call with a request containing the flags key, an enti
    }
 
 - bubbleSort(words)
++ flag, err := s.flipt.Evaluation().Boolean(r.Context(), &evaluation.EvaluationRequest{
++   FlagKey: "use-quicksort-algorithm",
++   EntityId: getUser(r.Context()),
++   Context: map[string]string{
++     "organization": getOrganization(r.Context()),
++   },
++ })
++
++ if flag.Enabled {
++   quicksort(words)
++ } else {
++   bubblesort(words)
++ }
 
-* flag, err := s.flipt.Evaluation().Boolean(r.Context(), &evaluation.EvaluationRequest{
-* FlagKey: "use-quicksort-algorithm",
-* EntityId: getUser(r.Context()),
-* Context: map[string]string{
-*      "organization": getOrganization(r.Context()),
-* },
-* })
-*
-* if flag.Enabled {
-* quicksort(words)
-* } else {
-* bubblesort(words)
-* }
-
-  if err := json.NewEncoder(w).Encode(words); err != nil {
-  http.Error(w, err.Error(), http.StatusInternalServerError)
-  return
-  }
-  }
-
-````
+   if err := json.NewEncoder(w).Encode(words); err != nil {
+     http.Error(w, err.Error(), http.StatusInternalServerError)
+     return
+   }
+ }
+```
 
 ```go pkg/server/words.go
 func (s *Server) ListWords(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Fixes FLI-735

This addresses the issues with the example configuration not being valid for Flipt consumption.
Many of the examples were missing a name and the segments has missing names, match type and an incorrectly keyed `operator`.

I fixed up all the examples and ran them through `flipt validate` to ensure they were valid.
I also updated all the sights where this guide presents a `diff` view, so that you can toggle between the diff and the raw (highlighted) full code. So that you can easily copy and paste the example directly (diff wasn't very friendly for copy/paste).


https://github.com/flipt-io/docs/assets/1253326/4e74a569-1305-49e9-8ea7-9d3926f31f7b