### PR TITLE
chore(authentication): update docs to reflect the Go SDK kubernetes provider support

### DIFF
--- a/authentication/methods.mdx
+++ b/authentication/methods.mdx
@@ -152,11 +152,8 @@ These two endpoints are necessary to support the different legs of the OAuth flo
 ## Kubernetes
 
 <Note>
-This method is designed for automatically authenticating applications with Flipt.
-
-We're actively designing and developing client-side implementations to leverage this method seamlessly.
-However, for now, the API must be managed manually by your implementation.
-
+  This method is designed for automatically authenticating applications with
+  Flipt.
 </Note>
 
 The `kubernetes` authentication method supports the ability to exchange [Kubernetes service account](https://kubernetes.io/docs/concepts/security/service-accounts) tokens with Flipt for client tokens.

--- a/authentication/methods.mdx
+++ b/authentication/methods.mdx
@@ -196,20 +196,21 @@ import (
 )
 
 func main() {
-  // The following constructs an instance of the SDK which communicates with
-  // instances of Flipt deployed in the same cluster.
-  // In this example, we assume Flipt is reachable via a k8s service named
-  // `flipt` deployed into the namespace `flipt`.
-  //
-  // The kubernetes provider automatically authenticates the client with this
-  // Flipt service. It also ensures that the credentials are kept up to date
-  // and automatically refreshed before they expire.
-  transport := http.NewTransport("http://flipt.flipt.svc.cluster.local:8080")
-  sdk := sdk.New(transport, sdk.WithAuthenticationProvider(
-    sdk.NewKubernetesAuthenticationProvider(transport),
-  ))
+// The following constructs an instance of the SDK which communicates with
+// instances of Flipt deployed in the same cluster.
+// In this example, we assume Flipt is reachable via a k8s service named
+// `flipt` deployed into the namespace `flipt`.
+//
+// The kubernetes provider automatically authenticates the client with this
+// Flipt service. It also ensures that the credentials are kept up to date
+// and automatically refreshed before they expire.
+transport := http.NewTransport("http://flipt.flipt.svc.cluster.local:8080")
+sdk := sdk.New(transport, sdk.WithAuthenticationProvider(
+sdk.NewKubernetesAuthenticationProvider(transport),
+))
 }
-```
+
+````
 
 </CodeGroup>
 
@@ -242,7 +243,7 @@ curl -s -X POST http://flipt:8080/auth/v1/method/kubernetes/serviceaccount \
     }
   }
 }
-```
+````
 
 </CodeGroup>
 

--- a/authentication/methods.mdx
+++ b/authentication/methods.mdx
@@ -176,10 +176,48 @@ If your Kubernetes environment has short-lived service account tokens, care will
 
 The client token produced can be used in subsequent API requests with the rest of the Flipt API to gain authenticated access.
 
+### Via the SDK
+
+Some of our SDKs support automatic authentication via the Kubernetes authentication method.
+These clients do not require you to have to manually invoke the verify service account.
+Instead, they do this operation for you, and they ensure that the retrieved client token from Flipt is automatically refreshed.
+
+The SDKs that currently support this include:
+
+- Go
+
+<CodeGroup>
+```go sdk.go
+package main
+
+import (
+  http "go.flipt.io/flipt/sdk/go/http"
+  sdk "go.flipt.io/flipt/sdk/go"
+)
+
+func main() {
+  // The following constructs an instance of the SDK which communicates with
+  // instances of Flipt deployed in the same cluster.
+  // In this example, we assume Flipt is reachable via a k8s service named
+  // `flipt` deployed into the namespace `flipt`.
+  //
+  // The kubernetes provider automatically authenticates the client with this
+  // Flipt service. It also ensures that the credentials are kept up to date
+  // and automatically refreshed before they expire.
+  transport := http.NewTransport("http://flipt.flipt.svc.cluster.local:8080")
+  sdk := sdk.New(transport, sdk.WithAuthenticationProvider(
+    sdk.NewKubernetesAuthenticationProvider(transport),
+  ))
+}
+```
+
+</CodeGroup>
+
+
 ### Via the API
 
-The following can be issued from inside a pod with a valid service account token in the default location for Kubernetes.
-It assumes that Flipt is reachable and deployed in the same cluster with a service name of `flipt`.
+Acquiring a client token via this method can be performed manually from inside a pod.
+The following uses `curl` to illustrate how a local, valid service account token can be used in this way.
 
 <CodeGroup>
 ```bash client-token.sh
@@ -203,60 +241,6 @@ curl -s -X POST http://flipt:8080/auth/v1/method/kubernetes/serviceaccount \
       "io.flipt.auth.k8s.serviceaccount.uid": "8aeb28ad-66f0-4884-bafc-e606e5eda149"
     }
   }
-}
-```
-
-```go client_http.go
-package client
-
-import (
-	"fmt"
-	"encoding/json"
-	"net/http"
-	"os"
-)
-
-type Response struct {
-	ClientToken    string `json:"clientToken"`
-	Authentication struct {
-		ExpiresAt time.Time `json:"expiresAt"`
-	} `json:"authentication"`
-}
-
-func getClientToken(ctx context.Context) (*Response, error) {
-	saToken, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/token")
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequestWithContext(
-		ctx,
-		http.MethodPost,
-		"http://flipt:8080/auth/v1/method/kubernetes/serviceaccount",
-		map[string]string{
-			"service_account_token": saToken,
-		})
-	if err != nil {
-		return nil, err
-	}
-
-	resp, err := http.Do(req)
-	if err != nil {
-		return nil, err
-	}
-
-	defer resp.Body.Close()
-
-	if resp.Status != http.StatusOK {
-		return nil, fmt.Errorf("unexpected status code: %q", resp.Status)
-	}
-
-	response := &Response{}
-	if err := json.NewDecoder(resp.Body).Decode(response); err != nil {
-		return nil, err
-	}
-
-	return response, nil
 }
 ```
 

--- a/authentication/methods.mdx
+++ b/authentication/methods.mdx
@@ -187,6 +187,7 @@ The SDKs that currently support this include:
 - Go
 
 <CodeGroup>
+
 ```go sdk.go
 package main
 
@@ -196,24 +197,22 @@ import (
 )
 
 func main() {
-// The following constructs an instance of the SDK which communicates with
-// instances of Flipt deployed in the same cluster.
-// In this example, we assume Flipt is reachable via a k8s service named
-// `flipt` deployed into the namespace `flipt`.
-//
-// The kubernetes provider automatically authenticates the client with this
-// Flipt service. It also ensures that the credentials are kept up to date
-// and automatically refreshed before they expire.
-transport := http.NewTransport("http://flipt.flipt.svc.cluster.local:8080")
-sdk := sdk.New(transport, sdk.WithAuthenticationProvider(
-sdk.NewKubernetesAuthenticationProvider(transport),
-))
+  // The following constructs an instance of the SDK which communicates with
+  // instances of Flipt deployed in the same cluster.
+  // In this example, we assume Flipt is reachable via a k8s service named
+  // `flipt` deployed into the namespace `flipt`.
+  //
+  // The kubernetes provider automatically authenticates the client with this
+  // Flipt service. It also ensures that the credentials are kept up to date
+  // and automatically refreshed before they expire.
+  transport := http.NewTransport("http://flipt.flipt.svc.cluster.local:8080")
+    sdk := sdk.New(transport, sdk.WithAuthenticationProvider(
+  sdk.NewKubernetesAuthenticationProvider(transport),
+  ))
 }
-
-````
+```
 
 </CodeGroup>
-
 
 ### Via the API
 
@@ -221,6 +220,7 @@ Acquiring a client token via this method can be performed manually from inside a
 The following uses `curl` to illustrate how a local, valid service account token can be used in this way.
 
 <CodeGroup>
+
 ```bash client-token.sh
 # assumes both curl and jq are installed
 curl -s -X POST http://flipt:8080/auth/v1/method/kubernetes/serviceaccount \
@@ -243,7 +243,7 @@ curl -s -X POST http://flipt:8080/auth/v1/method/kubernetes/serviceaccount \
     }
   }
 }
-````
+```
 
 </CodeGroup>
 

--- a/authentication/methods.mdx
+++ b/authentication/methods.mdx
@@ -206,8 +206,8 @@ func main() {
   // Flipt service. It also ensures that the credentials are kept up to date
   // and automatically refreshed before they expire.
   transport := http.NewTransport("http://flipt.flipt.svc.cluster.local:8080")
-    sdk := sdk.New(transport, sdk.WithAuthenticationProvider(
-  sdk.NewKubernetesAuthenticationProvider(transport),
+  sdk := sdk.New(transport, sdk.WithAuthenticationProvider(
+    sdk.NewKubernetesAuthenticationProvider(transport),
   ))
 }
 ```

--- a/guides/deploy-to-kubernetes.mdx
+++ b/guides/deploy-to-kubernetes.mdx
@@ -145,5 +145,3 @@ Please refer to the [Flipt Helm chart repository](https://github.com/flipt-io/he
 
 Additionally, you should checkout our documentation on our native [Kubernetes authentication method](/authentication/methods#kubernetes).
 This method can be leverage to automatically authenticate clients, without the need to manually manage credentials, for applications deployed into the same Kubernetes cluster as Flipt.
-
-

--- a/guides/deploy-to-kubernetes.mdx
+++ b/guides/deploy-to-kubernetes.mdx
@@ -142,3 +142,8 @@ Congratulations! You've successfully deployed Flipt to a local Kubernetes cluste
 You should be able to take the knowledge you've gained in this guide and deploy Flipt in to a real Kubernetes cluster.
 
 Please refer to the [Flipt Helm chart repository](https://github.com/flipt-io/helm-charts) for more information on how to configure Flipt using the Helm chart.
+
+Additionally, you should checkout our documentation on our native [Kubernetes authentication method](/authentication/methods#kubernetes).
+This method can be leverage to automatically authenticate clients, without the need to manually manage credentials, for applications deployed into the same Kubernetes cluster as Flipt.
+
+


### PR DESCRIPTION
This updates the documentation to illustrate how (for Go apps) the SDK now supports automatic kubernetes authentication via the authentication method and the SDK provider.