### PR TITLE
chore: change install link to shortlink

### DIFF
--- a/self-hosted/overview.mdx
+++ b/self-hosted/overview.mdx
@@ -8,7 +8,7 @@ Flipt is a single binary that can be run on any Linux or macOS (arm64) host. You
 <CodeGroup>
 
 ```console Binary
-curl -fsSL https://github.com/flipt-io/flipt/raw/main/install.sh | sh
+curl -fsSL https://get.flipt.io/install | sh
 ```
 
 ```console Docker
@@ -75,7 +75,7 @@ You can always download the latest release archive of Flipt from the
 You can use the following script to download and install the latest Flipt binary:
 
 ```console
-curl -fsSL https://github.com/flipt-io/flipt/raw/main/install.sh | sh
+curl -fsSL https://get.flipt.io/install | sh
 ```
 
 This will install Flipt to `/usr/local/bin/flipt` on Mac and Linux systems.


### PR DESCRIPTION
curl -fsSL https://get.flipt.io/install | sh