### PR TITLE
chore(configuration/authentication): add k8s troubleshooting documentation for discovery URL

### DIFF
--- a/configuration/authentication.mdx
+++ b/configuration/authentication.mdx
@@ -371,7 +371,7 @@ Further explanation for using this method can be found in the [Authentication: K
 **verifying service account: failed to verify signature: fetching keys oidc**
 
 In some managed Kubernetes cluster environments, the default cluster OIDC provider is replaced with the platform's managed alternative.
-For example, EKS clusters leverage this so that they can issue service accounts tokens which can assume the capabilites of AWS IAM roles.
+For example, EKS clusters leverage this so that they can issue service account tokens which can assume the capabilities of AWS IAM roles.
 
 In this situation, the default OIDC discovery URL is not appropriate for fetching key material from.
 Instead, you should locate your clusters OIDC URL and use that instead.

--- a/configuration/authentication.mdx
+++ b/configuration/authentication.mdx
@@ -370,7 +370,7 @@ Further explanation for using this method can be found in the [Authentication: K
 
 **verifying service account: failed to verify signature: fetching keys oidc**
 
-In some managed Kubernetes cluster environments, the default cluster OIDC provider is replaced with the platforms managed alternative.
+In some managed Kubernetes cluster environments, the default cluster OIDC provider is replaced with the platform's managed alternative.
 For example, EKS clusters leverage this so that they can issue service accounts tokens which can assume the capabilites of AWS IAM roles.
 
 In this situation, the default OIDC discovery URL is not appropriate for fetching key material from.

--- a/configuration/authentication.mdx
+++ b/configuration/authentication.mdx
@@ -366,6 +366,36 @@ Once enabled, client tokens can be retrieved by sending a Kubernetes pod's servi
 
 Further explanation for using this method can be found in the [Authentication: Kubernetes](/authentication/methods#kubernetes) documentation.
 
+#### Troubleshooting
+
+**verifying service account: failed to verify signature: fetching keys oidc**
+
+In some managed Kubernetes cluster environments, the default cluster OIDC provider is replaced with the platforms managed alternative.
+For example, EKS clusters leverage this so that they can issue service accounts tokens which can assume the capabilites of AWS IAM roles.
+
+In this situation, the default OIDC discovery URL is not appropriate for fetching key material from.
+Instead, you should locate your clusters OIDC URL and use that instead.
+
+<Note>
+Your cluster's OIDC URL will vary between Kubernetes providers.
+For example, here is some documentation which should help for EKS: [EKS troubleshoot OIDC and IRSA](https://repost.aws/knowledge-center/eks-troubleshoot-oidc-and-irsa).
+</Note>
+
+It is also important to note that custom OIDC providers likely will use HTTPS which has been signed with certificates not authorized by the cluster TLS certificate authority.
+In this situation, you can override the `kubernetes` auth providers `ca_path` field with relevant key material.
+The `flipt` distributed Docker image has valid and trusted certificates in `/etc/ssl/certs/ca-certificates.crt`, which can be appropriate if your OIDC provider has certificates granted by a valid public certificate authority.
+
+```yaml example-config-for-eks.yaml
+authentication:
+  methods:
+    kubernetes:
+      enabled: true
+      discovery_url: https://oidc.eks.us-west-2.amazonaws.com/id/EXAMPLED539D4633E53DE1B716D3041E # note: yours will be different
+      ca_path: /etc/ssl/certs/ca-certificates.crt # this can be enough if your OIDC provider TLS certificates have been signed by a public certificate authority
+```
+
+See [this issue](https://github.com/flipt-io/flipt/issues/2942) for more context. 
+
 ### JSON Web Token
 
 The `jwt` method provides the ability to authenticate with Flipt using an externally issued JSON Web Token. This method is useful for integrating with other authentication systems that can issue JWTs (e.g. [Auth0](https://auth0.com/docs/tokens/json-web-tokens)) or by generating your own signed JWTs on the fly.

--- a/configuration/authentication.mdx
+++ b/configuration/authentication.mdx
@@ -373,7 +373,7 @@ Further explanation for using this method can be found in the [Authentication: K
 In some managed Kubernetes cluster environments, the default cluster OIDC provider is replaced with the platform's managed alternative.
 For example, EKS clusters leverage this so that they can issue service account tokens which can assume the capabilities of AWS IAM roles.
 
-In this situation, the default OIDC discovery URL is not appropriate for fetching key material from.
+In this situation, the default OIDC discovery URL isn't appropriate for fetching key material from.
 Instead, you should locate your clusters OIDC URL and use that instead.
 
 <Note>
@@ -382,7 +382,7 @@ Instead, you should locate your clusters OIDC URL and use that instead.
   and IRSA](https://repost.aws/knowledge-center/eks-troubleshoot-oidc-and-irsa).
 </Note>
 
-It is also important to note that custom OIDC providers likely will use HTTPS which has been signed with certificates not authorized by the cluster TLS certificate authority.
+It's also important to note that custom OIDC providers likely will use HTTPS which has been signed with certificates not authorized by the cluster TLS certificate authority.
 In this situation, you can override the `kubernetes` auth providers `ca_path` field with relevant key material.
 The `flipt` distributed Docker image has valid and trusted certificates in `/etc/ssl/certs/ca-certificates.crt`, which can be appropriate if your OIDC provider has certificates granted by a valid public certificate authority.
 

--- a/configuration/authentication.mdx
+++ b/configuration/authentication.mdx
@@ -377,8 +377,9 @@ In this situation, the default OIDC discovery URL is not appropriate for fetchin
 Instead, you should locate your clusters OIDC URL and use that instead.
 
 <Note>
-Your cluster's OIDC URL will vary between Kubernetes providers.
-For example, here is some documentation which should help for EKS: [EKS troubleshoot OIDC and IRSA](https://repost.aws/knowledge-center/eks-troubleshoot-oidc-and-irsa).
+  Your cluster's OIDC URL will vary between Kubernetes providers. For example,
+  here is some documentation which should help for EKS: [EKS troubleshoot OIDC
+  and IRSA](https://repost.aws/knowledge-center/eks-troubleshoot-oidc-and-irsa).
 </Note>
 
 It is also important to note that custom OIDC providers likely will use HTTPS which has been signed with certificates not authorized by the cluster TLS certificate authority.
@@ -394,7 +395,7 @@ authentication:
       ca_path: /etc/ssl/certs/ca-certificates.crt # this can be enough if your OIDC provider TLS certificates have been signed by a public certificate authority
 ```
 
-See [this issue](https://github.com/flipt-io/flipt/issues/2942) for more context. 
+See [this issue](https://github.com/flipt-io/flipt/issues/2942) for more context.
 
 ### JSON Web Token
 


### PR DESCRIPTION
Closes https://github.com/flipt-io/flipt/issues/2942

This adds troubleshooting documentation around what to do in the face of OIDC jwks fetching errors.
It documents how certain Kubernetes cluster environments use custom OIDC issuers, and how to configure Flipt to work with them (with some EKS examples based on the experience in the issue).

Thanks @tstraley for raising this and working through the solution!