### PR TITLE
chore: rm outdated 'as of' docs

### DIFF
--- a/.vale/styles/Flipt/spelling-exceptions.txt
+++ b/.vale/styles/Flipt/spelling-exceptions.txt
@@ -9,6 +9,7 @@ codeowners
 codespaces
 config
 darwin
+datadog
 datetime
 declaratively
 deletable

--- a/configuration/analytics.mdx
+++ b/configuration/analytics.mdx
@@ -5,7 +5,7 @@ description: This document describes various configuration mechanisms for contro
 
 ## Analytics
 
-As of [v1.37.0](https://github.com/flipt-io/flipt/releases/tag/v1.37.0), Flipt includes functionality for reporting analytical data to a configurable storage engine.
+Flipt includes functionality for reporting analytical data to a configurable storage engine.
 
 Currently, Flipt has support for collecting data into the following storage engines:
 

--- a/configuration/auditing/webhooks.mdx
+++ b/configuration/auditing/webhooks.mdx
@@ -81,11 +81,10 @@ audit:
             }
 ```
 
-<Note>
-  As of [v1.39.0](https://github.com/flipt-io/flipt/releases/tag/v1.39.0), the
-  Go template contains a `toJson` utility method that will transform an input
-  into JSON if it fits the structure.
-</Note>
+<Tip>
+  The Go template contains a `toJson` utility function that will transform an
+  input into JSON if it fits the structure.
+</Tip>
 
 This configuration tells Flipt to send a `POST` request when events need to be emitted to the URL `https://example.com` with the HTTP headers, `Content-Type` and `Authorization`, and the body which is a [Go template](https://pkg.go.dev/text/template) that will be executed when an event comes in. The event structure looks like this:
 

--- a/configuration/authentication.mdx
+++ b/configuration/authentication.mdx
@@ -325,7 +325,7 @@ authentication:
 
 #### Allowed Teams
 
-As of version [1.39.0](https://github.com/flipt-io/flipt/releases/tag/v1.39.0) of Flipt, the GitHub authentication method also supports the ability to restrict access to a set of GitHub teams. This is important if you want to limit access to Flipt to only members of a specific team within an organization as opposed to all members of the organization.
+The GitHub authentication method also supports the ability to restrict access to a set of GitHub teams. This is important if you want to limit access to Flipt to only members of a specific team within an organization as opposed to all members of the organization.
 
 To enable this feature, set the `github.allowed_teams` configuration value to a list of GitHub teams within existing allowed organizations. For example:
 

--- a/configuration/observability.mdx
+++ b/configuration/observability.mdx
@@ -28,11 +28,14 @@ go_gc_duration_seconds{quantile="1"} 0.00026651 go_gc_duration_seconds_sum
 An [example](https://github.com/flipt-io/flipt/tree/main/examples/metrics)
 showing how to set up Flipt with Prometheus can be found in the GitHub repository.
 
-As of `v1.41.0` you can disable the Prometheus metrics collection by setting the `metrics.enabled` configuration option to `false`.
+<Tip>
+  You can disable the Prometheus metrics collection by setting the
+  `metrics.enabled` configuration option to `false`.
+</Tip>
 
 ### OTLP
 
-Flipt supports sending metrics to an [OTLP](https://opentelemetry.io/docs/concepts/data-collection/) collector as of `v1.41.0`.
+Flipt supports sending metrics to an [OTLP](https://opentelemetry.io/docs/concepts/data-collection/) collector.
 
 OTLP supports additional configuration such as specifying the protocol to use (gRPC or HTTP) as well as providing custom headers to send with the request.
 
@@ -72,7 +75,7 @@ log:
   encoding: json
 ```
 
-For production deployments, we recommend using the JSON format as it's easier to parse and ingest into log aggregation systems such as Elasticsearch, Splunk, Loki, or DataDog.
+For production deployments, we recommend using the JSON format as it's easier to parse and ingest into log aggregation systems such as Elasticsearch, Splunk, Loki, or Datadog.
 
 We've prepared an [example](https://github.com/flipt-io/flipt/tree/main/examples/audit/log) showing how to set up Flipt with Grafana Loki and Promtail to ingest and query logs.
 
@@ -119,11 +122,11 @@ Enable tracing via the values described in the [Tracing configuration](/configur
 
 ### OTLP
 
-![DataDog OTLP](/images/configuration/datadog_otlp.png)
+![Datadog OTLP](/images/configuration/datadog_otlp.png)
 
 OTLP supports additional configuration such as specifying the protocol to use (gRPC or HTTP) as well as providing custom headers to send with the request.
 
-Custom headers can be used to provide authentication information to the collector which may be required if you are using a hosted collector such as [NewRelic](https://docs.newrelic.com/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/get-started/opentelemetry-set-up-your-app/), [DataDog](https://docs.datadoghq.com/opentelemetry/otlp_ingest_in_the_agent/?tab=host), or [Honeycomb](https://docs.honeycomb.io/getting-data-in/opentelemetry-overview/#instrumenting-with-opentelemetry).
+Custom headers can be used to provide authentication information to the collector which may be required if you are using a hosted collector such as [NewRelic](https://docs.newrelic.com/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/get-started/opentelemetry-set-up-your-app/), [Datadog](https://docs.datadoghq.com/opentelemetry/otlp_ingest_in_the_agent/?tab=host), or [Honeycomb](https://docs.honeycomb.io/getting-data-in/opentelemetry-overview/#instrumenting-with-opentelemetry).
 
 These can be configured via the `tracing.otlp` configuration section.
 
@@ -139,7 +142,7 @@ tracing:
 
 #### Environment Variables
 
-As of [v1.38.0](https://github.com/flipt-io/flipt/releases/tag/v1.38.0), we now allow users to provide OTLP specific resource environment variables that are part of the [OTLP spec](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/).
+Flipt supports OTLP specific resource environment variables that are part of the [OTLP spec](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/).
 
 The following environment variables are supported:
 

--- a/configuration/overview.mdx
+++ b/configuration/overview.mdx
@@ -19,8 +19,8 @@ This file is read when Flipt starts up and configures several important
 properties for the server.
 
 <Tip>
-  You can generate a default configuration file by running `flipt config init`
-  as of v1.28.0. See the [CLI](/cli) documentation for more information.
+  You can generate a default configuration file by running `flipt config init`.
+  See the [CLI](/cli) documentation for more information.
 </Tip>
 
 The server will check in a few different locations for server configuration (in order):
@@ -42,7 +42,7 @@ pick up the new changes.
 
 ### Remote Configuration
 
-As of `v1.41.0`, Flipt supports fetching configuration from a remote source. This is useful for managing configuration across multiple instances of Flipt. The remote configuration source can be a URL to a configuration file stored in one of the following object storage services:
+Flipt supports fetching configuration from a remote source. This is useful for managing configuration across multiple instances of Flipt. The remote configuration source can be a URL to a configuration file stored in one of the following object storage services:
 
 - S3 (e.g.: `s3://bucket-name/path/to/config.yml`)
 - Azure Blob Storage (e.g.: `azblob://container-name/path/to/config.yml`)

--- a/configuration/storage.mdx
+++ b/configuration/storage.mdx
@@ -183,7 +183,7 @@ This cadence is also configurable and defaults to 30 seconds.
 
 Flipt will follow the configured [reference](https://git-scm.com/book/en/v2/Git-Internals-Git-References) and keep up to date with new changes.
 
-As of v1.41.0, Flipt supports the following reference types:
+Flipt supports the following reference types:
 
 - `static` (default): Flipt will use the reference provided in the configuration.
 - `semver`: Flipt will use the latest reference that matches the [semver](https://semver.org/) pattern (e.g. `v1.0.*`).


### PR DESCRIPTION
- Got tired of all the `as of X version` sections in the docs
- Datadog is spelled like that, not DataDog