### PR TITLE
fix(configuration): correct reference for git access token

### DIFF
--- a/configuration/overview.mdx
+++ b/configuration/overview.mdx
@@ -327,7 +327,7 @@ export FLIPT_CORS_ALLOWED_ORIGINS="http://localhost:3000 http://localhost:3001"
 | storage.git.directory                                   | The root directory to search in the repository                         |         | v1.40.0 |
 | storage.git.authentication.basic.username               | The username to use for basic authentication                           |         | v1.25.0 |
 | storage.git.authentication.basic.password               | The password to use for basic authentication                           |         | v1.25.0 |
-| storage.git.authentication.token                        | The access token to use for authentication                             |         | v1.25.0 |
+| storage.git.authentication.token.access_token           | The access token to use for authentication                             |         | v1.25.0 |
 | storage.git.authentication.ssh.password                 | Password used to generate the SSH key pair                             |         | v1.30.0 |
 | storage.git.authentication.ssh.private_key_path         | Path to private key on the filesystem                                  |         | v1.30.0 |
 | storage.git.authentication.ssh.private_key_bytes        | (Alternative) Raw private key bytes                                    |         | v1.30.0 |


### PR DESCRIPTION
Fixup the configuration overview for section for git storage authentication via tokens.
As per comment in https://github.com/flipt-io/flipt/issues/2271#issuecomment-2248383092 this was incorrectly defined in this section and missed the trailing `access_token` field.