### PR TITLE
fix: login with keycloak redirect url typo

### DIFF
--- a/guides/operation/authentication/login-with-keycloak.mdx
+++ b/guides/operation/authentication/login-with-keycloak.mdx
@@ -81,7 +81,7 @@ Create a new client called `flipt`:
 1. Ensure `OpenID Connect` is selected as the client type.
 1. Enter `flipt` as the client ID and click on `Next`.
 1. Ensure the `Standard flow` and `Direct access grants` are enabled and click on `Next`.
-1. Set the `Valid Redirect URIs` to `http://localhost:8081/auth/vl/method/oidc/keycloak/callback`.
+1. Set the `Valid Redirect URIs` to `http://localhost:8081/auth/v1/method/oidc/keycloak/callback`.
 1. Set the `Web Origins` to `http://localhost:8081`.
 1. Ensure `Client authentication` is set to `ON`.
 1. Click on `Save`.


### PR DESCRIPTION
Should be **v1** not **vl**