### PR TITLE
Fix git backend path config key

### DIFF
--- a/configuration/overview.mdx
+++ b/configuration/overview.mdx
@@ -334,7 +334,7 @@ export FLIPT_CORS_ALLOWED_ORIGINS="http://localhost:3000 http://localhost:3001"
 | storage.git.authentication.ssh.private_key_bytes        | (Alternative) Raw private key bytes                                    |         | v1.30.0 |
 | storage.git.authentication.ssh.insecure_ignore_host_key | Skip verifying the known hosts key (avoid in production)               | false   | v1.30.0 |
 | storage.git.backend.type                                | The backend to use for git repository storage (options: memory, local) | memory  | v1.43.0 |
-| storage.git.backend.local.path                          | The path to the local storage directory for git backend                |         | v1.43.0 |
+| storage.git.backend.path                                | The path to the local storage directory for git backend                |         | v1.43.0 |
 
 #### Storage Object
 


### PR DESCRIPTION
Doc had incorrect configuration param defined.

As seen in the code here https://github.com/flipt-io/flipt/blob/3b647a49ce43223272e65db5aaa0d9daed770a67/internal/storage/fs/store/store.go#L51