### PR TITLE
Update JSON logs documentation to include 'error' field

### DIFF
--- a/configuration/observability.mdx
+++ b/configuration/observability.mdx
@@ -65,8 +65,8 @@ You can find the dashboards in our [grafana-dashboards](https://github.com/flipt
 
 Flipt writes logs to STDOUT in two formats:
 
-- JSON
-- Console
+- [JSON](#json)
+- [Console'(#console)
 
 The format can be configured via the `log.encoding` configuration option.
 
@@ -103,6 +103,12 @@ We've prepared an [example](https://github.com/flipt-io/flipt/tree/main/examples
 - `L`: Level (log level). Possible values include: debug, info, warn, error, fatal, and panic.
 - `T`: Timestamp. The timestamp is in ISO 8601 format, widely used for representing date and time. It includes the date, time, and time zone information. For example, "2024-01-20T21:59:49-05:00" represents the date and time in the Eastern Time Zone (UTC-5).
 - `M`: Message. The message describes the log event. It can include information about the operation, errors encountered, or other relevant details.
+
+### Console
+
+```text
+2024-01-20T22:04:18-05:00	INFO	finished unary call with code OK	{"server": "grpc", "grpc.start_time": "2024-01-20T22:04:18-05:00", "system": "grpc", "span.kind": "server", "grpc.service": "flipt.evaluation.EvaluationService", "grpc.method": "Boolean", "peer.address": "127.0.0.1:53714", "grpc.code": "OK", "grpc.time_ms": 0.373}
+```
 
 More information about the available configuration options can be found in the [Logging configuration](/configuration/overview#logging) section.
 

--- a/configuration/observability.mdx
+++ b/configuration/observability.mdx
@@ -79,11 +79,30 @@ For production deployments, we recommend using the JSON format as it's easier to
 
 We've prepared an [example](https://github.com/flipt-io/flipt/tree/main/examples/audit/log) showing how to set up Flipt with Grafana Loki and Promtail to ingest and query logs.
 
-### Log Key Descriptions
+### JSON
 
-- `L`: Level (log level). Possible values include: debug, info, warn, error, fatal, panic.
-- `T`: Timestamp. The timestamp is in ISO 8601 format, which is a widely used format for representing date and time. It includes the date, time, and time zone information. For example, "2024-01-20T21:59:49-05:00" represents the date and time in the Eastern Time Zone (UTC-5).
-- `M`: Message. The message provides a description of the log event. It can include information about the operation being performed, any errors encountered, or other relevant details.
+```json
+{
+  "L": "INFO",
+  "T": "2024-01-20T21:59:49-05:00",
+  "M": "finished unary call with code OK",
+  "server": "grpc",
+  "grpc.start_time": "2024-01-20T21:59:49-05:00",
+  "system": "grpc",
+  "span.kind": "server",
+  "grpc.service": "flipt.evaluation.EvaluationService",
+  "grpc.method": "Boolean",
+  "peer.address": "127.0.0.1:52635",
+  "grpc.code": "OK",
+  "grpc.time_ms": 0.146
+}
+```
+
+#### Log Key Descriptions
+
+- `L`: Level (log level). Possible values include: debug, info, warn, error, fatal, and panic.
+- `T`: Timestamp. The timestamp is in ISO 8601 format, widely used for representing date and time. It includes the date, time, and time zone information. For example, "2024-01-20T21:59:49-05:00" represents the date and time in the Eastern Time Zone (UTC-5).
+- `M`: Message. The message describes the log event. It can include information about the operation, errors encountered, or other relevant details.
 
 More information about the available configuration options can be found in the [Logging configuration](/configuration/overview#logging) section.
 

--- a/configuration/observability.mdx
+++ b/configuration/observability.mdx
@@ -66,7 +66,7 @@ You can find the dashboards in our [grafana-dashboards](https://github.com/flipt
 Flipt writes logs to STDOUT in two formats:
 
 - [JSON](#json)
-- [Console'(#console)
+- [Console](#console)
 
 The format can be configured via the `log.encoding` configuration option.
 

--- a/configuration/observability.mdx
+++ b/configuration/observability.mdx
@@ -79,30 +79,11 @@ For production deployments, we recommend using the JSON format as it's easier to
 
 We've prepared an [example](https://github.com/flipt-io/flipt/tree/main/examples/audit/log) showing how to set up Flipt with Grafana Loki and Promtail to ingest and query logs.
 
-### JSON
+### Log Key Descriptions
 
-```json
-{
-  "L": "INFO",
-  "T": "2024-01-20T21:59:49-05:00",
-  "M": "finished unary call with code OK",
-  "server": "grpc",
-  "grpc.start_time": "2024-01-20T21:59:49-05:00",
-  "system": "grpc",
-  "span.kind": "server",
-  "grpc.service": "flipt.evaluation.EvaluationService",
-  "grpc.method": "Boolean",
-  "peer.address": "127.0.0.1:52635",
-  "grpc.code": "OK",
-  "grpc.time_ms": 0.146
-}
-```
-
-### Console
-
-```text
-2024-01-20T22:04:18-05:00	INFO	finished unary call with code OK	{"server": "grpc", "grpc.start_time": "2024-01-20T22:04:18-05:00", "system": "grpc", "span.kind": "server", "grpc.service": "flipt.evaluation.EvaluationService", "grpc.method": "Boolean", "peer.address": "127.0.0.1:53714", "grpc.code": "OK", "grpc.time_ms": 0.373}
-```
+- `L`: Level (log level). Possible values include: debug, info, warn, error, fatal, panic.
+- `T`: Timestamp. The timestamp is in ISO 8601 format, which is a widely used format for representing date and time. It includes the date, time, and time zone information. For example, "2024-01-20T21:59:49-05:00" represents the date and time in the Eastern Time Zone (UTC-5).
+- `M`: Message. The message provides a description of the log event. It can include information about the operation being performed, any errors encountered, or other relevant details.
 
 More information about the available configuration options can be found in the [Logging configuration](/configuration/overview#logging) section.
 


### PR DESCRIPTION
Fixes #300

Update JSON logs documentation to include 'error' field and explain log keys

* Add a section explaining what each key stands for.
* Include possible values for the 'L' key.
* Mention that the 'error' field may appear in the log.
* Elaborate on the timestamp and message descriptions.

