### PR TITLE
docs: add Azure DevOps support to v2 documentation

### DIFF
--- a/v2/configuration/environments.mdx
+++ b/v2/configuration/environments.mdx
@@ -122,11 +122,11 @@ environments:
   or Gitea, you will need to configure the API URL.
 </Tip>
 
-Environments can be configured to use a single Source Control Management (SCM) provider such as GitHub, GitLab, Gitea, or Bitbucket.
+Environments can be configured to use a single Source Control Management (SCM) provider such as GitHub, GitLab, Gitea, Azure DevOps, or Bitbucket.
 
 <Info>
-  Currently only GitHub, GitLab, and Gitea are supported. We will add support
-  for Bitbucket upon request.
+  Currently GitHub, GitLab, Gitea, and Azure DevOps are supported. We will add
+  support for Bitbucket upon request.
 </Info>
 
 See the [Git SCM Integration](/v2/guides/operations/environments/git-scm) guide for more information on how to configure Flipt v2 to use a SCM provider.

--- a/v2/configuration/storage.mdx
+++ b/v2/configuration/storage.mdx
@@ -163,7 +163,7 @@ credentials:
 
 #### Access Token
 
-Access tokens are a type of credential that are used to authenticate with a remote repository. These can be used for any remote repository provider that supports access tokens such as GitHub, GitLab, and Gitea.
+Access tokens are a type of credential that are used to authenticate with a remote repository. These can be used for any remote repository provider that supports access tokens such as GitHub, GitLab, Gitea, and Azure DevOps.
 
 ```yaml
 credentials:

--- a/v2/guides/operations/environments/git-scm.mdx
+++ b/v2/guides/operations/environments/git-scm.mdx
@@ -17,7 +17,7 @@ import V2Pro from "/snippets/v2-pro.mdx";
 
 <Note>
   Flipt v2 SCM integration supports most of the major Git providers including
-  GitHub, GitLab, and Gitea.
+  GitHub, GitLab, Gitea, and Azure DevOps.
 </Note>
 
 ## Configuring SCM Integration

--- a/v2/guides/operations/environments/git-sync.mdx
+++ b/v2/guides/operations/environments/git-sync.mdx
@@ -11,8 +11,8 @@ This guide will show you how to configure Flipt to sync your data to a Git repos
 - A GitHub Account and a repository to sync to
 
 <Note>
-  Flipt v2 supports any Git provider including Gitea, GitLab, Bitbucket, and is
-  not limited to GitHub.
+  Flipt v2 supports any Git provider including Gitea, GitLab, Bitbucket, Azure
+  DevOps, and is not limited to GitHub.
 </Note>
 
 ## Using GitHub for Git Sync

--- a/v2/guides/user/environments/merge-proposals.mdx
+++ b/v2/guides/user/environments/merge-proposals.mdx
@@ -18,7 +18,7 @@ import V2Pro from "/snippets/v2-pro.mdx";
 
 <Note>
   Flipt v2 merge proposals are supported by most of the major Git providers
-  including GitHub, GitLab, and Gitea.
+  including GitHub, GitLab, Gitea, and Azure DevOps.
 </Note>
 
 ## Using Merge Proposals


### PR DESCRIPTION
Updated v2 documentation to include Azure DevOps alongside GitHub/GitLab/Gitea for git sync and pull request functionality.

Changes:
- Added Azure DevOps to SCM integration providers lists
- Updated git sync documentation to mention Azure DevOps support
- Added Azure DevOps to merge proposals documentation
- Updated environment configuration docs with Azure DevOps support
- Added Azure DevOps to access token authentication examples

Fixes #328

Generated with [Claude Code](https://claude.ai/code)