### PR TITLE
docs: update for Flipt Cloud shutdown on August 29, 2025

### DIFF
--- a/authorization/overview.mdx
+++ b/authorization/overview.mdx
@@ -187,14 +187,12 @@ The `input.request` field contains information about the incoming request. This 
 - `namespace`: The [namespace](/concepts#namespaces) in Flipt of the resource being accessed. If no namespace is provided, the default namespace is used, or it is not applicable as the resource is not namespace scoped (e.g. authentication)
 
 - `resource`: The resource being accessed. This can be one of:
-
   - `namespace`: Access to [namespace](/concepts#namespaces) resources (e.g., listing or creating namespaces).
   - `flag`: Access to [flag](/concepts#flags) resources and sub-resources (e.g., listing or creating flags, variants, rules or rollouts).
   - `segment`: Access to [segment](/concepts#segments) resources and sub-resources (e.g., listing or creating segments, constraints or distributions).
   - `authentication`: Access to authentication resources (e.g., listing or creating client tokens).
 
 - `subject`: The (optional) nested subject of the request. This can be one of:
-
   - `namespace`: Access to [namespace](/concepts#namespaces) resources.
   - `flag`: Access to [flag](/concepts#flags) resources.
     - `variant`: Access to flag [variant](/concepts#variant-flags) resources.

--- a/cloud/architecture.mdx
+++ b/cloud/architecture.mdx
@@ -5,9 +5,10 @@ mode: "wide"
 ---
 
 <Note>
-**⚠️ Flipt Cloud Shutdown Notice**
+**Flipt Cloud Shutdown Notice**
 
 Flipt Cloud will be shutting down on **August 29, 2025**. We understand this is a significant change, and we're committed to helping you through this transition. Please read our [blog post](https://blog.flipt.io/sunsetting-flipt-cloud) for more details about this decision and guidance on migrating to self-hosted Flipt.
+
 </Note>
 
 This section describes the high-level architecture of Flipt Cloud and how you can also run your own Flipt instances for evaluation purposes while still leveraging the service.

--- a/cloud/architecture.mdx
+++ b/cloud/architecture.mdx
@@ -4,6 +4,12 @@ description: Learn about the architecture of Flipt Cloud and how it scales to me
 mode: "wide"
 ---
 
+<Note>
+**⚠️ Flipt Cloud Shutdown Notice**
+
+Flipt Cloud will be shutting down on **August 29, 2025**. We understand this is a significant change, and we're committed to helping you through this transition. Please read our [blog post](https://blog.flipt.io/sunsetting-flipt-cloud) for more details about this decision and guidance on migrating to self-hosted Flipt.
+</Note>
+
 This section describes the high-level architecture of Flipt Cloud and how you can also run your own Flipt instances for evaluation purposes while still leveraging the service.
 
 ## Overview

--- a/cloud/benefits.mdx
+++ b/cloud/benefits.mdx
@@ -4,6 +4,12 @@ description: Discover the benefits of Flipt Cloud and why it's the best choice f
 mode: "wide"
 ---
 
+<Note>
+**⚠️ Flipt Cloud Shutdown Notice**
+
+Flipt Cloud will be shutting down on **August 29, 2025**. We understand this is a significant change, and we're committed to helping you through this transition. Please read our [blog post](https://blog.flipt.io/sunsetting-flipt-cloud) for more details about this decision and guidance on migrating to self-hosted Flipt.
+</Note>
+
 <Info>
   Ready to try Flipt Cloud? [Sign up here](https://flipt.cloud) for a 14-day
   free trial.

--- a/cloud/benefits.mdx
+++ b/cloud/benefits.mdx
@@ -5,15 +5,11 @@ mode: "wide"
 ---
 
 <Note>
-**⚠️ Flipt Cloud Shutdown Notice**
+**Flipt Cloud Shutdown Notice**
 
 Flipt Cloud will be shutting down on **August 29, 2025**. We understand this is a significant change, and we're committed to helping you through this transition. Please read our [blog post](https://blog.flipt.io/sunsetting-flipt-cloud) for more details about this decision and guidance on migrating to self-hosted Flipt.
-</Note>
 
-<Info>
-  Ready to try Flipt Cloud? [Sign up here](https://flipt.cloud) for a 14-day
-  free trial.
-</Info>
+</Note>
 
 At Flipt, we aim to provide our users with the best possible feature flagging experience. That's why we're excited to introduce Flipt Cloud, a new offering that combines the best of both worlds: the simplicity and flexibility of a cloud service with the scalability and reliability of self-hosted Flipt.
 

--- a/cloud/concepts.mdx
+++ b/cloud/concepts.mdx
@@ -3,6 +3,12 @@ title: Concepts
 description: This document describes the basic concepts of Flipt Cloud.
 ---
 
+<Note>
+**⚠️ Flipt Cloud Shutdown Notice**
+
+Flipt Cloud will be shutting down on **August 29, 2025**. We understand this is a significant change, and we're committed to helping you through this transition. Please read our [blog post](https://blog.flipt.io/sunsetting-flipt-cloud) for more details about this decision and guidance on migrating to self-hosted Flipt.
+</Note>
+
 <Info>
   Ready to try Flipt Cloud? [Sign up here](https://flipt.cloud) for a 14-day
   free trial.

--- a/cloud/concepts.mdx
+++ b/cloud/concepts.mdx
@@ -4,15 +4,11 @@ description: This document describes the basic concepts of Flipt Cloud.
 ---
 
 <Note>
-**⚠️ Flipt Cloud Shutdown Notice**
+**Flipt Cloud Shutdown Notice**
 
 Flipt Cloud will be shutting down on **August 29, 2025**. We understand this is a significant change, and we're committed to helping you through this transition. Please read our [blog post](https://blog.flipt.io/sunsetting-flipt-cloud) for more details about this decision and guidance on migrating to self-hosted Flipt.
-</Note>
 
-<Info>
-  Ready to try Flipt Cloud? [Sign up here](https://flipt.cloud) for a 14-day
-  free trial.
-</Info>
+</Note>
 
 Flipt Cloud is a fully managed solution where we host and operate Flipt for you. You no longer need to deploy or manage Flipt instances yourself. We provide a secure, scalable, and feature-rich environment with enterprise-grade authentication and authorization built-in.
 

--- a/cloud/guides/getting-started.mdx
+++ b/cloud/guides/getting-started.mdx
@@ -3,11 +3,6 @@ title: Getting Started
 description: Learn how to get started with Flipt Cloud
 ---
 
-<Info>
-  Ready to try Flipt Cloud? [Sign up here](https://flipt.cloud) for a 14-day
-  free trial.
-</Info>
-
 ## Prerequisites
 
 Before you get started with Flipt Cloud, you need to have the following:

--- a/cloud/guides/production.mdx
+++ b/cloud/guides/production.mdx
@@ -3,10 +3,6 @@ title: Moving to Production
 description: Learn how to scale your feature flagging operations with Flipt Cloud
 ---
 
-<Info>
-Ready to try Flipt Cloud? [Sign up here](https://flipt.cloud) for a 14-day free trial.
-</Info>
-
 ## Prerequisites
 
 Before you move to production, you need to have the following:

--- a/cloud/overview.mdx
+++ b/cloud/overview.mdx
@@ -4,9 +4,10 @@ description: Our Cloud offering is the simplest, scalable solution for getting s
 ---
 
 <Note>
-**⚠️ Flipt Cloud Shutdown Notice**
+**Flipt Cloud Shutdown Notice**
 
 Flipt Cloud will be shutting down on **August 29, 2025**. We understand this is a significant change, and we're committed to helping you through this transition. Please read our [blog post](https://blog.flipt.io/sunsetting-flipt-cloud) for more details about this decision and guidance on migrating to self-hosted Flipt.
+
 </Note>
 
 <div style={{ padding: "56.25% 0 0 0", position: "relative" }}>

--- a/cloud/overview.mdx
+++ b/cloud/overview.mdx
@@ -3,6 +3,12 @@ title: Introduction
 description: Our Cloud offering is the simplest, scalable solution for getting started with Flipt without the need to manage your own infrastructure.
 ---
 
+<Note>
+**⚠️ Flipt Cloud Shutdown Notice**
+
+Flipt Cloud will be shutting down on **August 29, 2025**. We understand this is a significant change, and we're committed to helping you through this transition. Please read our [blog post](https://blog.flipt.io/sunsetting-flipt-cloud) for more details about this decision and guidance on migrating to self-hosted Flipt.
+</Note>
+
 <div style={{ padding: "56.25% 0 0 0", position: "relative" }}>
   <iframe
     src="https://player.vimeo.com/video/1000844872?badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479"

--- a/docs.json
+++ b/docs.json
@@ -535,6 +535,9 @@
     "light": "/logo/light-logo.svg",
     "dark": "/logo/dark-logo.svg"
   },
+  "banner": {
+    "content": "⚠️ **Flipt Cloud is shutting down on August 29, 2025.** [Learn more about this decision and next steps in our blog post](https://blog.flipt.io/sunsetting-flipt-cloud)."
+  },
   "api": {
     "openapi": "https://raw.githubusercontent.com/flipt-io/flipt/main/openapi.yaml",
     "playground": {
@@ -553,13 +556,7 @@
       "dark": "#121212"
     }
   },
-  "navbar": {
-    "primary": {
-      "type": "button",
-      "label": "Login to Flipt Cloud",
-      "href": "https://flipt.cloud/login"
-    }
-  },
+  "navbar": {},
   "footer": {
     "socials": {
       "website": "https://www.flipt.io/",

--- a/docs.json
+++ b/docs.json
@@ -536,7 +536,8 @@
     "dark": "/logo/dark-logo.svg"
   },
   "banner": {
-    "content": "⚠️ **Flipt Cloud is shutting down on August 29, 2025.** [Learn more about this decision and next steps in our blog post](https://blog.flipt.io/sunsetting-flipt-cloud)."
+    "content": "⚠️ **Flipt Cloud is shutting down on August 29, 2025.** [Learn more about this decision and next steps in our blog post](https://blog.flipt.io/sunsetting-flipt-cloud).",
+    "dismissible": true
   },
   "api": {
     "openapi": "https://raw.githubusercontent.com/flipt-io/flipt/main/openapi.yaml",

--- a/guides/migration/launchdarkly/openfeature.mdx
+++ b/guides/migration/launchdarkly/openfeature.mdx
@@ -149,11 +149,11 @@ In the LaunchDarkly SDK, here's how you fetch the value of a boolean flag:
 const booleanFlagValue = await ldClient.boolVariation(
   featureFlags.booleanFlag.key,
   context,
-  false
+  false,
 );
 doSomethingDependingOnFeatureFlagValue(
   featureFlags.booleanFlag.key,
-  booleanFlagValue
+  booleanFlagValue,
 );
 ```
 
@@ -165,8 +165,8 @@ ldClient
   .then((flagValue) =>
     doSomethingDependingOnFeatureFlagValue(
       featureFlags.booleanFlag.key,
-      flagValue
-    )
+      flagValue,
+    ),
   );
 ```
 
@@ -180,8 +180,8 @@ ldClient
   .then((flagValue) =>
     doSomethingDependingOnFeatureFlagValue(
       featureFlags.booleanFlag.key,
-      flagValue
-    )
+      flagValue,
+    ),
   );
 ```
 
@@ -193,8 +193,8 @@ ldClient
   .then((flagValue) =>
     doSomethingDependingOnFeatureFlagValue(
       featureFlags.booleanFlag.key,
-      flagValue
-    )
+      flagValue,
+    ),
   );
 ```
 
@@ -210,8 +210,8 @@ ldClient
   .then((flagValue) =>
     doSomethingDependingOnFeatureFlagValue(
       featureFlags.booleanFlag.key,
-      flagValue
-    )
+      flagValue,
+    ),
   );
 ```
 
@@ -223,8 +223,8 @@ client
   .then((flagValue) =>
     doSomethingDependingOnFeatureFlagValue(
       featureFlags.booleanFlag.key,
-      flagValue
-    )
+      flagValue,
+    ),
   );
 ```
 
@@ -236,8 +236,8 @@ ldClient
   .then((flagValue) =>
     doSomethingDependingOnFeatureFlagValue(
       featureFlags.booleanFlag.key,
-      flagValue
-    )
+      flagValue,
+    ),
   );
 ```
 
@@ -249,8 +249,8 @@ client
   .then((flagValue) =>
     doSomethingDependingOnFeatureFlagValue(
       featureFlags.booleanFlag.key,
-      flagValue
-    )
+      flagValue,
+    ),
   );
 ```
 
@@ -262,8 +262,8 @@ ldClient
   .then((flagValue) =>
     doSomethingDependingOnFeatureFlagValue(
       featureFlags.booleanFlag.key,
-      flagValue
-    )
+      flagValue,
+    ),
   );
 ```
 
@@ -275,8 +275,8 @@ client
   .then((flagValue) =>
     doSomethingDependingOnFeatureFlagValue(
       featureFlags.booleanFlag.key,
-      flagValue
-    )
+      flagValue,
+    ),
   );
 ```
 
@@ -295,8 +295,8 @@ ldClient
   .then((flagValue) =>
     doSomethingDependingOnFeatureFlagValue(
       featureFlags.stringFlag.key,
-      flagValue
-    )
+      flagValue,
+    ),
   );
 ```
 
@@ -306,11 +306,11 @@ or, using the async/await syntax:
 const stringFlagValue = await ldClient.stringVariation(
   featureFlags.stringFlag.key,
   context,
-  "red"
+  "red",
 );
 doSomethingDependingOnFeatureFlagValue(
   featureFlags.stringFlag.key,
-  stringFlagValue
+  stringFlagValue,
 );
 ```
 
@@ -324,8 +324,8 @@ ldClient
   .then((flagValue) =>
     doSomethingDependingOnFeatureFlagValue(
       featureFlags.stringFlag.key,
-      flagValue
-    )
+      flagValue,
+    ),
   );
 ```
 
@@ -337,8 +337,8 @@ client
   .then((flagValue) =>
     doSomethingDependingOnFeatureFlagValue(
       featureFlags.stringFlag.key,
-      flagValue
-    )
+      flagValue,
+    ),
   );
 ```
 
@@ -350,8 +350,8 @@ ldClient
   .then((flagValue) =>
     doSomethingDependingOnFeatureFlagValue(
       featureFlags.stringFlag.key,
-      flagValue
-    )
+      flagValue,
+    ),
   );
 ```
 
@@ -363,8 +363,8 @@ client
   .then((flagValue) =>
     doSomethingDependingOnFeatureFlagValue(
       featureFlags.stringFlag.key,
-      flagValue
-    )
+      flagValue,
+    ),
   );
 ```
 
@@ -376,8 +376,8 @@ ldClient
   .then((flagValue) =>
     doSomethingDependingOnFeatureFlagValue(
       featureFlags.stringFlag.key,
-      flagValue
-    )
+      flagValue,
+    ),
   );
 ```
 
@@ -389,8 +389,8 @@ client
   .then((flagValue) =>
     doSomethingDependingOnFeatureFlagValue(
       featureFlags.stringFlag.key,
-      flagValue
-    )
+      flagValue,
+    ),
   );
 ```
 
@@ -404,8 +404,8 @@ ldClient
   .then((flagValue) =>
     doSomethingDependingOnFeatureFlagValue(
       featureFlags.numberFlag.key,
-      flagValue
-    )
+      flagValue,
+    ),
   );
 ```
 
@@ -415,11 +415,11 @@ or using the async/await syntax:
 const numberFlagValue = await ldClient.numberVariation(
   featureFlags.numberFlag.key,
   context,
-  50
+  50,
 );
 doSomethingDependingOnFeatureFlagValue(
   featureFlags.numberFlag.key,
-  numberFlagValue
+  numberFlagValue,
 );
 ```
 
@@ -433,8 +433,8 @@ ldClient
   .then((flagValue) =>
     doSomethingDependingOnFeatureFlagValue(
       featureFlags.numberFlag.key,
-      flagValue
-    )
+      flagValue,
+    ),
   );
 ```
 
@@ -446,8 +446,8 @@ client
   .then((flagValue) =>
     doSomethingDependingOnFeatureFlagValue(
       featureFlags.numberFlag.key,
-      flagValue
-    )
+      flagValue,
+    ),
   );
 ```
 
@@ -459,8 +459,8 @@ ldClient
   .then((flagValue) =>
     doSomethingDependingOnFeatureFlagValue(
       featureFlags.numberFlag.key,
-      flagValue
-    )
+      flagValue,
+    ),
   );
 ```
 
@@ -472,8 +472,8 @@ client
   .then((flagValue) =>
     doSomethingDependingOnFeatureFlagValue(
       featureFlags.numberFlag.key,
-      flagValue
-    )
+      flagValue,
+    ),
   );
 ```
 
@@ -485,8 +485,8 @@ ldClient
   .then((flagValue) =>
     doSomethingDependingOnFeatureFlagValue(
       featureFlags.numberFlag.key,
-      flagValue
-    )
+      flagValue,
+    ),
   );
 ```
 
@@ -498,8 +498,8 @@ client
   .then((flagValue) =>
     doSomethingDependingOnFeatureFlagValue(
       featureFlags.numberFlag.key,
-      flagValue
-    )
+      flagValue,
+    ),
   );
 ```
 
@@ -517,7 +517,10 @@ You can call each of these functions with a promise call chain:
 ldClient
   .jsonVariation(featureFlags.jsonFlag.key, context, {})
   .then((flagValue) =>
-    doSomethingDependingOnFeatureFlagValue(featureFlags.jsonFlag.key, flagValue)
+    doSomethingDependingOnFeatureFlagValue(
+      featureFlags.jsonFlag.key,
+      flagValue,
+    ),
   );
 ```
 
@@ -527,11 +530,11 @@ or using the async/await syntax:
 const jsonFlagValue = await ldClient.jsonVariation(
   featureFlags.jsonFlag.key,
   context,
-  {}
+  {},
 );
 doSomethingDependingOnFeatureFlagValue(
   featureFlags.jsonFlag.key,
-  jsonFlagValue
+  jsonFlagValue,
 );
 ```
 
@@ -541,7 +544,10 @@ When migrating a `jsonVariation()` call to the OpenFeature SDK,
 ldClient
   .jsonVariation(featureFlags.jsonFlag.key, context, {})
   .then((flagValue) =>
-    doSomethingDependingOnFeatureFlagValue(featureFlags.jsonFlag.key, flagValue)
+    doSomethingDependingOnFeatureFlagValue(
+      featureFlags.jsonFlag.key,
+      flagValue,
+    ),
   );
 ```
 
@@ -551,7 +557,10 @@ becomes
 client
   .getObjectValue(featureFlags.jsonFlag.key, {}, context)
   .then((flagValue) =>
-    doSomethingDependingOnFeatureFlagValue(featureFlags.jsonFlag.key, flagValue)
+    doSomethingDependingOnFeatureFlagValue(
+      featureFlags.jsonFlag.key,
+      flagValue,
+    ),
   );
 ```
 
@@ -561,7 +570,10 @@ When migrating a `variation()` call,
 ldClient
   .variation(featureFlags.jsonFlag.key, context, {})
   .then((flagValue) =>
-    doSomethingDependingOnFeatureFlagValue(featureFlags.jsonFlag.key, flagValue)
+    doSomethingDependingOnFeatureFlagValue(
+      featureFlags.jsonFlag.key,
+      flagValue,
+    ),
   );
 ```
 
@@ -571,7 +583,10 @@ also becomes
 client
   .getObjectValue(featureFlags.jsonFlag.key, {}, context)
   .then((flagValue) =>
-    doSomethingDependingOnFeatureFlagValue(featureFlags.jsonFlag.key, flagValue)
+    doSomethingDependingOnFeatureFlagValue(
+      featureFlags.jsonFlag.key,
+      flagValue,
+    ),
   );
 ```
 
@@ -581,7 +596,10 @@ Finally, when migrating a `jsonVariationDetail()` call,
 ldClient
   .jsonVariationDetail(featureFlags.jsonFlag.key, context, {})
   .then((flagValue) =>
-    doSomethingDependingOnFeatureFlagValue(featureFlags.jsonFlag.key, flagValue)
+    doSomethingDependingOnFeatureFlagValue(
+      featureFlags.jsonFlag.key,
+      flagValue,
+    ),
   );
 ```
 
@@ -591,7 +609,10 @@ becomes
 client
   .getObjectDetails(featureFlags.jsonFlag.key, {}, context)
   .then((flagValue) =>
-    doSomethingDependingOnFeatureFlagValue(featureFlags.jsonFlag.key, flagValue)
+    doSomethingDependingOnFeatureFlagValue(
+      featureFlags.jsonFlag.key,
+      flagValue,
+    ),
   );
 ```
 
@@ -649,8 +670,8 @@ try {
 } catch (error) {
   console.log(
     `Failed to connect to LaunchDarkly :( Here's what the error says: ${JSON.stringify(
-      error
-    )}`
+      error,
+    )}`,
   );
 }
 ```
@@ -661,8 +682,8 @@ LaunchDarkly also allows listening to the `error` event that signals an abnormal
 ldClient.on("error", (error) => {
   console.log(
     `The LaunchDarkly client has encountered an error. Here are the details: ${JSON.stringify(
-      error
-    )}`
+      error,
+    )}`,
   );
 });
 ```
@@ -673,8 +694,8 @@ In OpenFeature SDK terms, the equivalent listener looks like this:
 OpenFeature.addHandler(ProviderEvents.Error, (error) => {
   console.log(
     `The OpenFeature client for LaunchDarkly has encountered an error. Here are the details: ${JSON.stringify(
-      error
-    )}`
+      error,
+    )}`,
   );
 });
 ```
@@ -689,7 +710,7 @@ ldClient.on("update", (keyObject) => {
   ldClient
     .variation(keyObject.key, context, false)
     .then((flagValue) =>
-      doSomethingDependingOnFeatureFlagValue(keyObject.key, flagValue)
+      doSomethingDependingOnFeatureFlagValue(keyObject.key, flagValue),
     );
 });
 ```
@@ -699,15 +720,15 @@ The `update:key` listener is more specific and serves to receive configuration u
 ```javascript
 ldClient.on(`update:${featureFlags.booleanFlag.key}`, () => {
   console.log(
-    `Configuration of flag ${featureFlags.booleanFlag.key} has changed`
+    `Configuration of flag ${featureFlags.booleanFlag.key} has changed`,
   );
   ldClient
     .variation(featureFlags.booleanFlag.key, context, false)
     .then((flagValue) =>
       doSomethingDependingOnFeatureFlagValue(
         featureFlags.booleanFlag.key,
-        flagValue
-      )
+        flagValue,
+      ),
     );
 });
 ```
@@ -719,7 +740,7 @@ OpenFeature.addHandler(
   ProviderEvents.ConfigurationChanged,
   async (_eventDetails) => {
     // your event handling code
-  }
+  },
 );
 ```
 
@@ -732,7 +753,7 @@ OpenFeature.addHandler(
     const changedFlag = _eventDetails.flagsChanged[0];
     console.log(`Configuration of flag ${changedFlag} has changed`);
     const flagType = Object.values(featureFlags).find(
-      (x) => x.key === changedFlag
+      (x) => x.key === changedFlag,
     ).type;
 
     let flagValue;
@@ -746,11 +767,11 @@ OpenFeature.addHandler(
       flagValue = await client.getObjectValue(changedFlag, null, context);
     } else {
       console.log(
-        "Something went awry: we don't know the type of the updated flag"
+        "Something went awry: we don't know the type of the updated flag",
       );
     }
     doSomethingDependingOnFeatureFlagValue(changedFlag, flagValue);
-  }
+  },
 );
 ```
 

--- a/installation/overview.mdx
+++ b/installation/overview.mdx
@@ -41,9 +41,6 @@ For more details on each installation method, see the sections below.
 - [Homebrew](#homebrew)
 - [Binary](#binary)
 
-<Card title="Flipt Cloud" icon="cloud" href="/cloud/overview">
-  Don't want to self-host? Learn more about our cloud offering.
-</Card>
 
 ## Homebrew
 

--- a/installation/overview.mdx
+++ b/installation/overview.mdx
@@ -41,7 +41,6 @@ For more details on each installation method, see the sections below.
 - [Homebrew](#homebrew)
 - [Binary](#binary)
 
-
 ## Homebrew
 
 You can install Flipt using [Homebrew](https://brew.sh/) on macOS and Linux.

--- a/integration/client.mdx
+++ b/integration/client.mdx
@@ -109,11 +109,4 @@ Flipt provides a number of client-side SDKs to help you integrate with Flipt in 
 
 By default, the SDKs will use a polling mechanism to sync the state of the flags with the Flipt server. You can set the polling interval using the `updateInterval` option in the SDK's configuration.
 
-If you are a [Flipt Cloud](/cloud/overview) user, you can enable `streaming` mode, which will make the SDK subscribe to changes on the Flipt server and update the state of the flags accordingly in real-time.
-
-<Card href="/cloud/overview" title="Flipt Cloud" icon="cloud">
-  Flipt Cloud is a fully managed feature management platform that enables you to
-  continue to use Flipt's feature management capabilities with zero maintenance.
-</Card>
-
-Streaming is available for all Flipt Cloud plans, even the free tier.
+Note: Flipt Cloud offered `streaming` mode for real-time flag updates, but Flipt Cloud is shutting down on August 29, 2025. If you're currently using Flipt Cloud, please read our [blog post](https://blog.flipt.io/sunsetting-flipt-cloud) for guidance on migrating to self-hosted Flipt.

--- a/integration/overview.mdx
+++ b/integration/overview.mdx
@@ -53,7 +53,6 @@ Client-side evaluation is another way Flipt supports evaluating feature flags. T
 
 Client-side evaluation is much more performant than server-side evaluation, but it comes with some tradeoffs. The main tradeoff is that you need to keep your feature flag rules in sync with Flipt. This means that you will need to periodically fetch the feature flag rules from Flipt and update your local copy. Our client-side SDKs provide a way to do this automatically.
 
-
 Reasons for using client-side evaluation include:
 
 - You want to reduce the number of requests your application makes to Flipt for feature flag evaluations

--- a/integration/overview.mdx
+++ b/integration/overview.mdx
@@ -53,11 +53,6 @@ Client-side evaluation is another way Flipt supports evaluating feature flags. T
 
 Client-side evaluation is much more performant than server-side evaluation, but it comes with some tradeoffs. The main tradeoff is that you need to keep your feature flag rules in sync with Flipt. This means that you will need to periodically fetch the feature flag rules from Flipt and update your local copy. Our client-side SDKs provide a way to do this automatically.
 
-<Tip>
-  If you are a [Flipt Cloud](/cloud/overview) user, you can enable streaming
-  mode, which will make the SDK subscribe to changes on the Flipt server and
-  update the state of the flags accordingly in real-time.
-</Tip>
 
 Reasons for using client-side evaluation include:
 

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -14,10 +14,6 @@ simulate an evaluation request from your applications.
 For more information on any of the concepts described, please see the
 [Concepts](/concepts) documentation.
 
-import Cloud from "/snippets/cloud.mdx";
-
-<Cloud />
-
 ## Setup
 
 Before getting started, make sure the Flipt server is up and running on your

--- a/reference/overview.mdx
+++ b/reference/overview.mdx
@@ -5,7 +5,7 @@ title: API Overview
 Flipt's API is the primary way to interact with Flipt Open Source outside of the UI. It's used to create, update, and delete entities such as namespaces, flags, segments, rules, and also to evaluate flags.
 
 <Note>
-**⚠️ Flipt Cloud Shutdown Notice**
+**Flipt Cloud Shutdown Notice**
 
 Flipt Cloud will be shutting down on **August 29, 2025**. If you're currently using Flipt Cloud, please read our [blog post](https://blog.flipt.io/sunsetting-flipt-cloud) for guidance on migrating to self-hosted Flipt.
 

--- a/reference/overview.mdx
+++ b/reference/overview.mdx
@@ -5,13 +5,11 @@ title: API Overview
 Flipt's API is the primary way to interact with Flipt Open Source outside of the UI. It's used to create, update, and delete entities such as namespaces, flags, segments, rules, and also to evaluate flags.
 
 <Note>
-  Flipt Cloud is a fully managed feature management platform that
-  enables you to continue to use Flipt's feature management capabilities with
-  zero maintenance.
+**⚠️ Flipt Cloud Shutdown Notice**
 
-Flipt Cloud only supports [Client-Side Evaluation](/integration/client) currently, so these API endpoints are not available if you are using Flipt Cloud.
+Flipt Cloud will be shutting down on **August 29, 2025**. If you're currently using Flipt Cloud, please read our [blog post](https://blog.flipt.io/sunsetting-flipt-cloud) for guidance on migrating to self-hosted Flipt.
 
-See the [Flipt Cloud Architecture](/cloud/architecture) section for more information.
+Note that Flipt Cloud only supported [Client-Side Evaluation](/integration/client), so these API endpoints were not available for Flipt Cloud users.
 
 </Note>
 

--- a/reo.js
+++ b/reo.js
@@ -1,6 +1,6 @@
 !(function () {
   var e, t, n;
-  (e = "a9505926280f383"),
+  ((e = "a9505926280f383"),
     (t = function () {
       Reo.init({ clientID: "a9505926280f383" });
     }),
@@ -8,5 +8,5 @@
       "https://static.reo.dev/" + e + "/reo.js"),
     (n.defer = !0),
     (n.onload = t),
-    document.head.appendChild(n);
+    document.head.appendChild(n));
 })();

--- a/snippets/cloud.mdx
+++ b/snippets/cloud.mdx
@@ -1,7 +1,0 @@
-<Note>
-**⚠️ Flipt Cloud Shutdown Notice**
-
-Flipt Cloud will be shutting down on **August 29, 2025**. We understand this is a significant change, and we're committed to helping you through this transition.
-
-If you're currently using Flipt Cloud, please read our [blog post](https://blog.flipt.io/sunsetting-flipt-cloud) for details about this decision and guidance on migrating to self-hosted Flipt.
-</Note>

--- a/snippets/cloud.mdx
+++ b/snippets/cloud.mdx
@@ -1,8 +1,7 @@
-<Card href="/cloud/overview" title="Flipt Cloud" icon="cloud">
-  Flipt Cloud is a fully managed feature management platform that
-  enables you to continue to use Flipt's feature management capabilities with
-  zero maintenance.
+<Note>
+**⚠️ Flipt Cloud Shutdown Notice**
 
-Own your feature data, backed by Git.
+Flipt Cloud will be shutting down on **August 29, 2025**. We understand this is a significant change, and we're committed to helping you through this transition.
 
-</Card>
+If you're currently using Flipt Cloud, please read our [blog post](https://blog.flipt.io/sunsetting-flipt-cloud) for details about this decision and guidance on migrating to self-hosted Flipt.
+</Note>

--- a/usecases/gitops.mdx
+++ b/usecases/gitops.mdx
@@ -12,7 +12,6 @@ Flipt is uniquely suited to work with GitOps workflows because of its declarativ
 
 We believe that feature flags are a form of configuration and should be treated as such. This means that feature flags should be able to be stored in the same repository as the code that uses them. This allows developers to make changes to both the code and the feature flags in the same pull request. This also allows developers to use the same GitOps tooling to deploy both their code and their feature flags to production.
 
-
 ## Git Backend
 
 Flipt's declarative storage backends allow it to run without a database at all. Flipt can be configured to load its feature flag data in the following ways:

--- a/usecases/gitops.mdx
+++ b/usecases/gitops.mdx
@@ -12,11 +12,6 @@ Flipt is uniquely suited to work with GitOps workflows because of its declarativ
 
 We believe that feature flags are a form of configuration and should be treated as such. This means that feature flags should be able to be stored in the same repository as the code that uses them. This allows developers to make changes to both the code and the feature flags in the same pull request. This also allows developers to use the same GitOps tooling to deploy both their code and their feature flags to production.
 
-<Card href="/cloud/overview" title="Flipt Cloud" icon="cloud">
-  Want a managed Flipt service that is GitOps native? Check out Flipt Cloud.
-  Your feature flag data is version controlled in your Git repositories and you
-  can manage your flags via the Flipt UI.
-</Card>
 
 ## Git Backend
 

--- a/v2/introduction.mdx
+++ b/v2/introduction.mdx
@@ -23,7 +23,7 @@ Flipt v2 is built to be Git-native, meaning that your feature flags and configur
 
 By default, Flipt v2 uses a local git-backed storage backend that is stored in memory or on disk. You can also configure Flipt v2 to sync your local git-backed storage to a remote Git repository such as GitHub, GitLab, or Bitbucket.
 
-We modeled Flipt v2 after our [Flipt Cloud](/cloud/overview) product, but with the ability to self-host.
+We modeled Flipt v2 after our Flipt Cloud product (which is shutting down on August 29, 2025), but with the ability to self-host.
 
 import Cloud from "/snippets/cloud.mdx";
 


### PR DESCRIPTION
This PR implements the documentation updates requested in issue #331 to announce the Flipt Cloud shutdown.

## Changes
- Added sitewide banner announcing Flipt Cloud shutdown
- Added shutdown notices to all main Flipt Cloud pages
- Removed/updated Flipt Cloud promotional content from non-Cloud pages
- Removed "Login to Flipt Cloud" button from navbar
- Updated references to direct users to migration blog post

Closes #331

Generated with [Claude Code](https://claude.ai/code)