### PR TITLE
docs: add offline license validation support for annual licenses

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@ This is the **user-facing** documentation repository for Flipt, a feature flag a
 - Make sure to use the correct tone and style for the target audience (developers, operators, etc.).
 - While the audience is technical, try to avoid using technical jargon and explain concepts in a way that is easy to understand.
 - **IMPORTANT**: Remember this is user-facing documentation, so we need to be very clear and concise and not go too deep into the technical details, but instead focus on how to use the product and how to configure it.
+- Always run `npm run lint` and `npm run format` before committing any changes
 
 ## Development Commands
 

--- a/authorization/overview.mdx
+++ b/authorization/overview.mdx
@@ -187,12 +187,14 @@ The `input.request` field contains information about the incoming request. This 
 - `namespace`: The [namespace](/concepts#namespaces) in Flipt of the resource being accessed. If no namespace is provided, the default namespace is used, or it is not applicable as the resource is not namespace scoped (e.g. authentication)
 
 - `resource`: The resource being accessed. This can be one of:
+
   - `namespace`: Access to [namespace](/concepts#namespaces) resources (e.g., listing or creating namespaces).
   - `flag`: Access to [flag](/concepts#flags) resources and sub-resources (e.g., listing or creating flags, variants, rules or rollouts).
   - `segment`: Access to [segment](/concepts#segments) resources and sub-resources (e.g., listing or creating segments, constraints or distributions).
   - `authentication`: Access to authentication resources (e.g., listing or creating client tokens).
 
 - `subject`: The (optional) nested subject of the request. This can be one of:
+
   - `namespace`: Access to [namespace](/concepts#namespaces) resources.
   - `flag`: Access to [flag](/concepts#flags) resources.
     - `variant`: Access to flag [variant](/concepts#variant-flags) resources.

--- a/guides/migration/launchdarkly/openfeature.mdx
+++ b/guides/migration/launchdarkly/openfeature.mdx
@@ -149,11 +149,11 @@ In the LaunchDarkly SDK, here's how you fetch the value of a boolean flag:
 const booleanFlagValue = await ldClient.boolVariation(
   featureFlags.booleanFlag.key,
   context,
-  false,
+  false
 );
 doSomethingDependingOnFeatureFlagValue(
   featureFlags.booleanFlag.key,
-  booleanFlagValue,
+  booleanFlagValue
 );
 ```
 
@@ -165,8 +165,8 @@ ldClient
   .then((flagValue) =>
     doSomethingDependingOnFeatureFlagValue(
       featureFlags.booleanFlag.key,
-      flagValue,
-    ),
+      flagValue
+    )
   );
 ```
 
@@ -180,8 +180,8 @@ ldClient
   .then((flagValue) =>
     doSomethingDependingOnFeatureFlagValue(
       featureFlags.booleanFlag.key,
-      flagValue,
-    ),
+      flagValue
+    )
   );
 ```
 
@@ -193,8 +193,8 @@ ldClient
   .then((flagValue) =>
     doSomethingDependingOnFeatureFlagValue(
       featureFlags.booleanFlag.key,
-      flagValue,
-    ),
+      flagValue
+    )
   );
 ```
 
@@ -210,8 +210,8 @@ ldClient
   .then((flagValue) =>
     doSomethingDependingOnFeatureFlagValue(
       featureFlags.booleanFlag.key,
-      flagValue,
-    ),
+      flagValue
+    )
   );
 ```
 
@@ -223,8 +223,8 @@ client
   .then((flagValue) =>
     doSomethingDependingOnFeatureFlagValue(
       featureFlags.booleanFlag.key,
-      flagValue,
-    ),
+      flagValue
+    )
   );
 ```
 
@@ -236,8 +236,8 @@ ldClient
   .then((flagValue) =>
     doSomethingDependingOnFeatureFlagValue(
       featureFlags.booleanFlag.key,
-      flagValue,
-    ),
+      flagValue
+    )
   );
 ```
 
@@ -249,8 +249,8 @@ client
   .then((flagValue) =>
     doSomethingDependingOnFeatureFlagValue(
       featureFlags.booleanFlag.key,
-      flagValue,
-    ),
+      flagValue
+    )
   );
 ```
 
@@ -262,8 +262,8 @@ ldClient
   .then((flagValue) =>
     doSomethingDependingOnFeatureFlagValue(
       featureFlags.booleanFlag.key,
-      flagValue,
-    ),
+      flagValue
+    )
   );
 ```
 
@@ -275,8 +275,8 @@ client
   .then((flagValue) =>
     doSomethingDependingOnFeatureFlagValue(
       featureFlags.booleanFlag.key,
-      flagValue,
-    ),
+      flagValue
+    )
   );
 ```
 
@@ -295,8 +295,8 @@ ldClient
   .then((flagValue) =>
     doSomethingDependingOnFeatureFlagValue(
       featureFlags.stringFlag.key,
-      flagValue,
-    ),
+      flagValue
+    )
   );
 ```
 
@@ -306,11 +306,11 @@ or, using the async/await syntax:
 const stringFlagValue = await ldClient.stringVariation(
   featureFlags.stringFlag.key,
   context,
-  "red",
+  "red"
 );
 doSomethingDependingOnFeatureFlagValue(
   featureFlags.stringFlag.key,
-  stringFlagValue,
+  stringFlagValue
 );
 ```
 
@@ -324,8 +324,8 @@ ldClient
   .then((flagValue) =>
     doSomethingDependingOnFeatureFlagValue(
       featureFlags.stringFlag.key,
-      flagValue,
-    ),
+      flagValue
+    )
   );
 ```
 
@@ -337,8 +337,8 @@ client
   .then((flagValue) =>
     doSomethingDependingOnFeatureFlagValue(
       featureFlags.stringFlag.key,
-      flagValue,
-    ),
+      flagValue
+    )
   );
 ```
 
@@ -350,8 +350,8 @@ ldClient
   .then((flagValue) =>
     doSomethingDependingOnFeatureFlagValue(
       featureFlags.stringFlag.key,
-      flagValue,
-    ),
+      flagValue
+    )
   );
 ```
 
@@ -363,8 +363,8 @@ client
   .then((flagValue) =>
     doSomethingDependingOnFeatureFlagValue(
       featureFlags.stringFlag.key,
-      flagValue,
-    ),
+      flagValue
+    )
   );
 ```
 
@@ -376,8 +376,8 @@ ldClient
   .then((flagValue) =>
     doSomethingDependingOnFeatureFlagValue(
       featureFlags.stringFlag.key,
-      flagValue,
-    ),
+      flagValue
+    )
   );
 ```
 
@@ -389,8 +389,8 @@ client
   .then((flagValue) =>
     doSomethingDependingOnFeatureFlagValue(
       featureFlags.stringFlag.key,
-      flagValue,
-    ),
+      flagValue
+    )
   );
 ```
 
@@ -404,8 +404,8 @@ ldClient
   .then((flagValue) =>
     doSomethingDependingOnFeatureFlagValue(
       featureFlags.numberFlag.key,
-      flagValue,
-    ),
+      flagValue
+    )
   );
 ```
 
@@ -415,11 +415,11 @@ or using the async/await syntax:
 const numberFlagValue = await ldClient.numberVariation(
   featureFlags.numberFlag.key,
   context,
-  50,
+  50
 );
 doSomethingDependingOnFeatureFlagValue(
   featureFlags.numberFlag.key,
-  numberFlagValue,
+  numberFlagValue
 );
 ```
 
@@ -433,8 +433,8 @@ ldClient
   .then((flagValue) =>
     doSomethingDependingOnFeatureFlagValue(
       featureFlags.numberFlag.key,
-      flagValue,
-    ),
+      flagValue
+    )
   );
 ```
 
@@ -446,8 +446,8 @@ client
   .then((flagValue) =>
     doSomethingDependingOnFeatureFlagValue(
       featureFlags.numberFlag.key,
-      flagValue,
-    ),
+      flagValue
+    )
   );
 ```
 
@@ -459,8 +459,8 @@ ldClient
   .then((flagValue) =>
     doSomethingDependingOnFeatureFlagValue(
       featureFlags.numberFlag.key,
-      flagValue,
-    ),
+      flagValue
+    )
   );
 ```
 
@@ -472,8 +472,8 @@ client
   .then((flagValue) =>
     doSomethingDependingOnFeatureFlagValue(
       featureFlags.numberFlag.key,
-      flagValue,
-    ),
+      flagValue
+    )
   );
 ```
 
@@ -485,8 +485,8 @@ ldClient
   .then((flagValue) =>
     doSomethingDependingOnFeatureFlagValue(
       featureFlags.numberFlag.key,
-      flagValue,
-    ),
+      flagValue
+    )
   );
 ```
 
@@ -498,8 +498,8 @@ client
   .then((flagValue) =>
     doSomethingDependingOnFeatureFlagValue(
       featureFlags.numberFlag.key,
-      flagValue,
-    ),
+      flagValue
+    )
   );
 ```
 
@@ -517,10 +517,7 @@ You can call each of these functions with a promise call chain:
 ldClient
   .jsonVariation(featureFlags.jsonFlag.key, context, {})
   .then((flagValue) =>
-    doSomethingDependingOnFeatureFlagValue(
-      featureFlags.jsonFlag.key,
-      flagValue,
-    ),
+    doSomethingDependingOnFeatureFlagValue(featureFlags.jsonFlag.key, flagValue)
   );
 ```
 
@@ -530,11 +527,11 @@ or using the async/await syntax:
 const jsonFlagValue = await ldClient.jsonVariation(
   featureFlags.jsonFlag.key,
   context,
-  {},
+  {}
 );
 doSomethingDependingOnFeatureFlagValue(
   featureFlags.jsonFlag.key,
-  jsonFlagValue,
+  jsonFlagValue
 );
 ```
 
@@ -544,10 +541,7 @@ When migrating a `jsonVariation()` call to the OpenFeature SDK,
 ldClient
   .jsonVariation(featureFlags.jsonFlag.key, context, {})
   .then((flagValue) =>
-    doSomethingDependingOnFeatureFlagValue(
-      featureFlags.jsonFlag.key,
-      flagValue,
-    ),
+    doSomethingDependingOnFeatureFlagValue(featureFlags.jsonFlag.key, flagValue)
   );
 ```
 
@@ -557,10 +551,7 @@ becomes
 client
   .getObjectValue(featureFlags.jsonFlag.key, {}, context)
   .then((flagValue) =>
-    doSomethingDependingOnFeatureFlagValue(
-      featureFlags.jsonFlag.key,
-      flagValue,
-    ),
+    doSomethingDependingOnFeatureFlagValue(featureFlags.jsonFlag.key, flagValue)
   );
 ```
 
@@ -570,10 +561,7 @@ When migrating a `variation()` call,
 ldClient
   .variation(featureFlags.jsonFlag.key, context, {})
   .then((flagValue) =>
-    doSomethingDependingOnFeatureFlagValue(
-      featureFlags.jsonFlag.key,
-      flagValue,
-    ),
+    doSomethingDependingOnFeatureFlagValue(featureFlags.jsonFlag.key, flagValue)
   );
 ```
 
@@ -583,10 +571,7 @@ also becomes
 client
   .getObjectValue(featureFlags.jsonFlag.key, {}, context)
   .then((flagValue) =>
-    doSomethingDependingOnFeatureFlagValue(
-      featureFlags.jsonFlag.key,
-      flagValue,
-    ),
+    doSomethingDependingOnFeatureFlagValue(featureFlags.jsonFlag.key, flagValue)
   );
 ```
 
@@ -596,10 +581,7 @@ Finally, when migrating a `jsonVariationDetail()` call,
 ldClient
   .jsonVariationDetail(featureFlags.jsonFlag.key, context, {})
   .then((flagValue) =>
-    doSomethingDependingOnFeatureFlagValue(
-      featureFlags.jsonFlag.key,
-      flagValue,
-    ),
+    doSomethingDependingOnFeatureFlagValue(featureFlags.jsonFlag.key, flagValue)
   );
 ```
 
@@ -609,10 +591,7 @@ becomes
 client
   .getObjectDetails(featureFlags.jsonFlag.key, {}, context)
   .then((flagValue) =>
-    doSomethingDependingOnFeatureFlagValue(
-      featureFlags.jsonFlag.key,
-      flagValue,
-    ),
+    doSomethingDependingOnFeatureFlagValue(featureFlags.jsonFlag.key, flagValue)
   );
 ```
 
@@ -670,8 +649,8 @@ try {
 } catch (error) {
   console.log(
     `Failed to connect to LaunchDarkly :( Here's what the error says: ${JSON.stringify(
-      error,
-    )}`,
+      error
+    )}`
   );
 }
 ```
@@ -682,8 +661,8 @@ LaunchDarkly also allows listening to the `error` event that signals an abnormal
 ldClient.on("error", (error) => {
   console.log(
     `The LaunchDarkly client has encountered an error. Here are the details: ${JSON.stringify(
-      error,
-    )}`,
+      error
+    )}`
   );
 });
 ```
@@ -694,8 +673,8 @@ In OpenFeature SDK terms, the equivalent listener looks like this:
 OpenFeature.addHandler(ProviderEvents.Error, (error) => {
   console.log(
     `The OpenFeature client for LaunchDarkly has encountered an error. Here are the details: ${JSON.stringify(
-      error,
-    )}`,
+      error
+    )}`
   );
 });
 ```
@@ -710,7 +689,7 @@ ldClient.on("update", (keyObject) => {
   ldClient
     .variation(keyObject.key, context, false)
     .then((flagValue) =>
-      doSomethingDependingOnFeatureFlagValue(keyObject.key, flagValue),
+      doSomethingDependingOnFeatureFlagValue(keyObject.key, flagValue)
     );
 });
 ```
@@ -720,15 +699,15 @@ The `update:key` listener is more specific and serves to receive configuration u
 ```javascript
 ldClient.on(`update:${featureFlags.booleanFlag.key}`, () => {
   console.log(
-    `Configuration of flag ${featureFlags.booleanFlag.key} has changed`,
+    `Configuration of flag ${featureFlags.booleanFlag.key} has changed`
   );
   ldClient
     .variation(featureFlags.booleanFlag.key, context, false)
     .then((flagValue) =>
       doSomethingDependingOnFeatureFlagValue(
         featureFlags.booleanFlag.key,
-        flagValue,
-      ),
+        flagValue
+      )
     );
 });
 ```
@@ -740,7 +719,7 @@ OpenFeature.addHandler(
   ProviderEvents.ConfigurationChanged,
   async (_eventDetails) => {
     // your event handling code
-  },
+  }
 );
 ```
 
@@ -753,7 +732,7 @@ OpenFeature.addHandler(
     const changedFlag = _eventDetails.flagsChanged[0];
     console.log(`Configuration of flag ${changedFlag} has changed`);
     const flagType = Object.values(featureFlags).find(
-      (x) => x.key === changedFlag,
+      (x) => x.key === changedFlag
     ).type;
 
     let flagValue;
@@ -767,11 +746,11 @@ OpenFeature.addHandler(
       flagValue = await client.getObjectValue(changedFlag, null, context);
     } else {
       console.log(
-        "Something went awry: we don't know the type of the updated flag",
+        "Something went awry: we don't know the type of the updated flag"
       );
     }
     doSomethingDependingOnFeatureFlagValue(changedFlag, flagValue);
-  },
+  }
 );
 ```
 

--- a/reo.js
+++ b/reo.js
@@ -1,6 +1,6 @@
 !(function () {
   var e, t, n;
-  ((e = "a9505926280f383"),
+  (e = "a9505926280f383"),
     (t = function () {
       Reo.init({ clientID: "a9505926280f383" });
     }),
@@ -8,5 +8,5 @@
       "https://static.reo.dev/" + e + "/reo.js"),
     (n.defer = !0),
     (n.onload = t),
-    document.head.appendChild(n));
+    document.head.appendChild(n);
 })();

--- a/snippets/v2-pro.mdx
+++ b/snippets/v2-pro.mdx
@@ -1,4 +1,6 @@
 <Tip>
   This functionality is only available in Flipt v2 Pro. [Learn
-  more](/v2/licensing) about our commercial license or purchase a [monthly](http://getflipt.co/pro/monthly) or [annual](http://getflipt.co/pro/annual) license.
+  more](/v2/licensing) about our commercial license or purchase a
+  [monthly](http://getflipt.co/pro/monthly) or
+  [annual](http://getflipt.co/pro/annual) license.
 </Tip>

--- a/snippets/v2-pro.mdx
+++ b/snippets/v2-pro.mdx
@@ -1,5 +1,4 @@
 <Tip>
   This functionality is only available in Flipt v2 Pro. [Learn
-  more](/v2/licensing) about our commercial license or [purchase a
-  license](/v2/licensing#purchasing-a-commercial-license).
+  more](/v2/licensing) about our commercial license or purchase a [monthly](http://getflipt.co/pro/monthly) or [annual](http://getflipt.co/pro/annual) license.
 </Tip>

--- a/snippets/v2-pro.mdx
+++ b/snippets/v2-pro.mdx
@@ -1,6 +1,6 @@
 <Tip>
   This functionality is only available in Flipt v2 Pro. [Learn
   more](/v2/licensing) about our commercial license or purchase a
-  [monthly](http://getflipt.co/pro/monthly) or
-  [annual](http://getflipt.co/pro/annual) license.
+  [monthly](https://getflipt.co/pro/monthly) or
+  [annual](https://getflipt.co/pro/annual) license.
 </Tip>

--- a/v2/configuration/licensing.mdx
+++ b/v2/configuration/licensing.mdx
@@ -43,7 +43,7 @@ You can configure the license key in the Flipt v2 configuration file or via envi
 
 ## Acquiring a License
 
-You can get a 14 day trial license for the Pro edition by purchasing a [monthly](https://getflipt.co/pro/monthly) or [annual](https://getflipt.co/pro/annual) license.
+You can get a 14 day trial license for the Pro edition by purchasing a [monthly](https://getflipt.co/pro/monthly) license. Note that trials are only available for monthly licenses, not [annual](https://getflipt.co/pro/annual) licenses.
 
 The license will be emailed to you after checkout. After the trial period, you will need to provide a payment method to continue using the Pro edition.
 

--- a/v2/configuration/licensing.mdx
+++ b/v2/configuration/licensing.mdx
@@ -43,7 +43,7 @@ You can configure the license key in the Flipt v2 configuration file or via envi
 
 ## Acquiring a License
 
-You can get a 14 day trial license for the Pro edition by purchasing a [monthly](http://getflipt.co/pro/monthly) or [annual](http://getflipt.co/pro/annual) license.
+You can get a 14 day trial license for the Pro edition by purchasing a [monthly](https://getflipt.co/pro/monthly) or [annual](https://getflipt.co/pro/annual) license.
 
 The license will be emailed to you after checkout. After the trial period, you will need to provide a payment method to continue using the Pro edition.
 
@@ -55,8 +55,8 @@ Fliptä v2 supports both **monthly** and **annual** commercial licenses:
 - **Annual licenses**: Support offline validation using license files for air-gapped environments
 
 <Tip>
-  Choose [monthly](http://getflipt.co/pro/monthly) for standard subscription or
-  [annual](http://getflipt.co/pro/annual) for offline validation support. You
+  Choose [monthly](https://getflipt.co/pro/monthly) for standard subscription or
+  [annual](https://getflipt.co/pro/annual) for offline validation support. You
   can also purchase a license by contacting us at
   [support@flipt.io](mailto:support@flipt.io).
 </Tip>

--- a/v2/configuration/licensing.mdx
+++ b/v2/configuration/licensing.mdx
@@ -43,7 +43,7 @@ You can configure the license key in the Flipt v2 configuration file or via envi
 
 ## Acquiring a License
 
-You can get a 14 day trial license for the Pro edition via our [Flipt v2 Pro License](https://getflipt.co/pro) purchase page.
+You can get a 14 day trial license for the Pro edition by purchasing a [monthly](http://getflipt.co/pro/monthly) or [annual](http://getflipt.co/pro/annual) license.
 
 The license will be emailed to you after checkout. After the trial period, you will need to provide a payment method to continue using the Pro edition.
 
@@ -55,8 +55,7 @@ Fliptä v2 supports both **monthly** and **annual** commercial licenses:
 - **Annual licenses**: Support offline validation using license files for air-gapped environments
 
 <Tip>
-  You can also purchase a license by contacting us at
-  [support@flipt.io](mailto:support@flipt.io).
+  Choose [monthly](http://getflipt.co/pro/monthly) for standard subscription or [annual](http://getflipt.co/pro/annual) for offline validation support. You can also purchase a license by contacting us at [support@flipt.io](mailto:support@flipt.io).
 </Tip>
 
 ### Trial Expiration

--- a/v2/configuration/licensing.mdx
+++ b/v2/configuration/licensing.mdx
@@ -49,7 +49,7 @@ The license will be emailed to you after checkout. After the trial period, you w
 
 ### License Types
 
-Fliptä v2 supports both **monthly** and **annual** commercial licenses:
+Flipt v2 supports both **monthly** and **annual** commercial licenses:
 
 - **Monthly licenses**: Require continuous internet connectivity for validation
 - **Annual licenses**: Support offline validation using license files for air-gapped environments

--- a/v2/configuration/licensing.mdx
+++ b/v2/configuration/licensing.mdx
@@ -20,6 +20,8 @@ You can configure the license key in the Flipt v2 configuration file or via envi
     ```yaml
     license:
       key: "your-license-key"
+      # Optional: Path to offline license file for annual licenses
+      file: "/path/to/license.lic"
     ```
 
   </Tab>
@@ -27,6 +29,8 @@ You can configure the license key in the Flipt v2 configuration file or via envi
 
     ```bash
     FLIPT_LICENSE_KEY="your-license-key"
+    # Optional: Path to offline license file for annual licenses
+    FLIPT_LICENSE_FILE="/path/to/license.lic"
     ```
 
   </Tab>
@@ -43,6 +47,13 @@ You can get a 14 day trial license for the Pro edition via our [Flipt v2 Pro Lic
 
 The license will be emailed to you after checkout. After the trial period, you will need to provide a payment method to continue using the Pro edition.
 
+### License Types
+
+Fliptä v2 supports both **monthly** and **annual** commercial licenses:
+
+- **Monthly licenses**: Require continuous internet connectivity for validation
+- **Annual licenses**: Support offline validation using license files for air-gapped environments
+
 <Tip>
   You can also purchase a license by contacting us at
   [support@flipt.io](mailto:support@flipt.io).
@@ -56,7 +67,7 @@ This means that you will lose functionality such as [Merge Proposals](/v2/introd
 
 ### License Renewal
 
-Paid licenses will be renewed automatically on a monthly basis. You can cancel the subscription at any time.
+Paid licenses will be renewed automatically based on your subscription type (monthly or annual). You can cancel the subscription at any time.
 
 <Warning>
   Cancellations take effect immediately and you will lose access to paid
@@ -78,10 +89,20 @@ Flipt v2 will continuously validate the license key every 12 hours.
 
 This means that you will **need to have an active network connection from the Flipt v2 instance to the internet** to validate the license key.
 
+### Offline License Validation
+
+For **annual license purchases**, Flipt v2 supports offline license validation using cryptographically signed license files. This allows you to run Flipt v2 in air-gapped environments without internet connectivity.
+
+To use offline validation:
+
+1. Purchase an annual license
+2. Download the provided license file (.lic)
+3. Configure the `file` path in your license configuration
+4. Restart your Flipt v2 instance
+
 <Note>
-  We are working on a solution to allow for offline validation of the license
-  key. If you have a specific use case that requires offline validation, please
-  contact us at [support@flipt.io](mailto:support@flipt.io).
+  Offline license validation is only available for annual license purchases.
+  Monthly licenses require continuous internet connectivity for validation.
 </Note>
 
 ### License Expiration

--- a/v2/configuration/licensing.mdx
+++ b/v2/configuration/licensing.mdx
@@ -55,7 +55,10 @@ Fliptä v2 supports both **monthly** and **annual** commercial licenses:
 - **Annual licenses**: Support offline validation using license files for air-gapped environments
 
 <Tip>
-  Choose [monthly](http://getflipt.co/pro/monthly) for standard subscription or [annual](http://getflipt.co/pro/annual) for offline validation support. You can also purchase a license by contacting us at [support@flipt.io](mailto:support@flipt.io).
+  Choose [monthly](http://getflipt.co/pro/monthly) for standard subscription or
+  [annual](http://getflipt.co/pro/annual) for offline validation support. You
+  can also purchase a license by contacting us at
+  [support@flipt.io](mailto:support@flipt.io).
 </Tip>
 
 ### Trial Expiration

--- a/v2/licensing.mdx
+++ b/v2/licensing.mdx
@@ -48,9 +48,12 @@ Flipt v2 offers both **monthly** and **annual** commercial license options:
 - **Monthly licenses**: Standard subscription with continuous internet validation
 - **Annual licenses**: Include offline validation support for air-gapped environments
 
-To purchase a commercial Flipt v2 Pro license, click the link below or scan the QR code:
+To purchase a commercial Flipt v2 Pro license, choose from our monthly or annual options:
 
-[Flipt v2 Pro License (with 14 day free trial)](https://getflipt.co/pro)
+- **[Monthly License](http://getflipt.co/pro/monthly)** - Standard subscription with continuous internet validation
+- **[Annual License](http://getflipt.co/pro/annual)** - Includes offline validation support for air-gapped environments
+
+Both options include a 14-day free trial.
 
 ## Commercial License FAQ
 
@@ -61,7 +64,7 @@ To purchase a commercial Flipt v2 Pro license, click the link below or scan the 
 
 2. **How do I get a license key?**
 
-   You can get a license key by purchasing a license from the [Flipt v2 Pro License](https://getflipt.co/pro) purchase page. The license will be emailed to you after checkout.
+   You can get a license key by purchasing a [monthly](http://getflipt.co/pro/monthly) or [annual](http://getflipt.co/pro/annual) license. The license will be emailed to you after checkout.
 
 3. **How do I configure the license key?**
 
@@ -69,7 +72,7 @@ To purchase a commercial Flipt v2 Pro license, click the link below or scan the 
 
 4. **Is there a free trial?**
 
-   Yes, you can get a 14 day free trial license by signing up for a license from the [Flipt v2 Pro License](https://getflipt.co/pro) purchase page. The license will be emailed to you after checkout.
+   Yes, you can get a 14 day free trial license by signing up for a [monthly](http://getflipt.co/pro/monthly) or [annual](http://getflipt.co/pro/annual) license. The license will be emailed to you after checkout.
 
 5. **How do I cancel my subscription?**
 

--- a/v2/licensing.mdx
+++ b/v2/licensing.mdx
@@ -50,8 +50,8 @@ Flipt v2 offers both **monthly** and **annual** commercial license options:
 
 To purchase a commercial Flipt v2 Pro license, choose from our monthly or annual options:
 
-- **[Monthly License](http://getflipt.co/pro/monthly)** - Standard subscription with continuous internet validation
-- **[Annual License](http://getflipt.co/pro/annual)** - Includes offline validation support for air-gapped environments
+- **[Monthly License](https://getflipt.co/pro/monthly)** - Standard subscription with continuous internet validation
+- **[Annual License](https://getflipt.co/pro/annual)** - Includes offline validation support for air-gapped environments
 
 Both options include a 14-day free trial.
 
@@ -64,7 +64,7 @@ Both options include a 14-day free trial.
 
 2. **How do I get a license key?**
 
-   You can get a license key by purchasing a [monthly](http://getflipt.co/pro/monthly) or [annual](http://getflipt.co/pro/annual) license. The license will be emailed to you after checkout.
+   You can get a license key by purchasing a [monthly](https://getflipt.co/pro/monthly) or [annual](https://getflipt.co/pro/annual) license. The license will be emailed to you after checkout.
 
 3. **How do I configure the license key?**
 
@@ -72,7 +72,7 @@ Both options include a 14-day free trial.
 
 4. **Is there a free trial?**
 
-   Yes, you can get a 14 day free trial license by signing up for a [monthly](http://getflipt.co/pro/monthly) or [annual](http://getflipt.co/pro/annual) license. The license will be emailed to you after checkout.
+   Yes, you can get a 14 day free trial license by signing up for a [monthly](https://getflipt.co/pro/monthly) or [annual](https://getflipt.co/pro/annual) license. The license will be emailed to you after checkout.
 
 5. **How do I cancel my subscription?**
 

--- a/v2/licensing.mdx
+++ b/v2/licensing.mdx
@@ -50,10 +50,10 @@ Flipt v2 offers both **monthly** and **annual** commercial license options:
 
 To purchase a commercial Flipt v2 Pro license, choose from our monthly or annual options:
 
-- **[Monthly License](https://getflipt.co/pro/monthly)** - Standard subscription with continuous internet validation
+- **[Monthly License](https://getflipt.co/pro/monthly)** - Standard subscription with continuous internet validation and 14-day free trial
 - **[Annual License](https://getflipt.co/pro/annual)** - Includes offline validation support for air-gapped environments
 
-Both options include a 14-day free trial.
+Monthly licenses include a 14-day free trial.
 
 ## Commercial License FAQ
 
@@ -72,7 +72,7 @@ Both options include a 14-day free trial.
 
 4. **Is there a free trial?**
 
-   Yes, you can get a 14 day free trial license by signing up for a [monthly](https://getflipt.co/pro/monthly) or [annual](https://getflipt.co/pro/annual) license. The license will be emailed to you after checkout.
+   Yes, you can get a 14 day free trial license by signing up for a [monthly](https://getflipt.co/pro/monthly) license. The license will be emailed to you after checkout. Note that trials are only available for monthly licenses, not annual licenses.
 
 5. **How do I cancel my subscription?**
 

--- a/v2/licensing.mdx
+++ b/v2/licensing.mdx
@@ -43,6 +43,11 @@ This includes:
 
 ## Purchasing a Commercial License
 
+Flipt v2 offers both **monthly** and **annual** commercial license options:
+
+- **Monthly licenses**: Standard subscription with continuous internet validation
+- **Annual licenses**: Include offline validation support for air-gapped environments
+
 To purchase a commercial Flipt v2 Pro license, click the link below or scan the QR code:
 
 [Flipt v2 Pro License (with 14 day free trial)](https://getflipt.co/pro)


### PR DESCRIPTION
Updates v2 documentation to document offline license validation support added in [flipт-io/flipt#4487](https://github.com/flipt-io/flipt/pull/4487).

## Changes

- Add file field to v2 licensing configuration examples
- Document offline validation for annual licenses only
- Update general licensing page to mention monthly and annual options
- Replace outdated note about offline validation being in development

Closes #333

Generated with [Claude Code](https://claude.ai/code)