### PR TITLE
docs: add authentication.session.csrf.secure config parameter

### DIFF
--- a/configuration/overview.mdx
+++ b/configuration/overview.mdx
@@ -186,6 +186,7 @@ export FLIPT_CORS_ALLOWED_ORIGINS="http://localhost:3000 http://localhost:3001"
 | authentication.session.token_lifetime | Configures the lifetime of the session token (login duration) | 24h     | v1.17.0 |
 | authentication.session.state_lifetime | Configures the lifetime of state parameters during OAuth flow | 10m     | v1.17.0 |
 | authentication.session.csrf.key       | Secret credential used to sign CSRF prevention tokens         |         | v1.17.0 |
+| authentication.session.csrf.secure    | Enable secure CSRF token enforcement                          | false   | v1.58.6 |
 
 #### Authentication Methods: Token
 

--- a/v2/configuration/overview.mdx
+++ b/v2/configuration/overview.mdx
@@ -270,8 +270,6 @@ export FLIPT_CORS_ALLOWED_ORIGINS="http://localhost:3000 http://localhost:3001"
 | authentication.session.state_lifetime | Configures the lifetime of state parameters during OAuth flow | 10m     | v2.0.0 |
 | authentication.session.csrf.key       | Secret credential used to sign CSRF prevention tokens         |         | v2.0.0 |
 | authentication.session.csrf.secure    | Enable secure CSRF token enforcement                          | false   | v2.0.0 |
-| authentication.session.token_lifetime | Configures the lifetime of the session token (login duration) | 24h     | v2.0.0 |
-| authentication.session.state_lifetime | Configures the lifetime of state parameters during OAuth flow | 10m     | v2.0.0 |
 
 #### Authentication Session Storage
 

--- a/v2/configuration/overview.mdx
+++ b/v2/configuration/overview.mdx
@@ -269,6 +269,7 @@ export FLIPT_CORS_ALLOWED_ORIGINS="http://localhost:3000 http://localhost:3001"
 | authentication.session.token_lifetime | Configures the lifetime of the session token (login duration) | 24h     | v2.0.0 |
 | authentication.session.state_lifetime | Configures the lifetime of state parameters during OAuth flow | 10m     | v2.0.0 |
 | authentication.session.csrf.key       | Secret credential used to sign CSRF prevention tokens         |         | v2.0.0 |
+| authentication.session.csrf.secure    | Enable secure CSRF token enforcement                          | false   | v2.0.0 |
 | authentication.session.token_lifetime | Configures the lifetime of the session token (login duration) | 24h     | v2.0.0 |
 | authentication.session.state_lifetime | Configures the lifetime of state parameters during OAuth flow | 10m     | v2.0.0 |
 


### PR DESCRIPTION
Add documentation for the secure CSRF config value to both v1 and v2 configuration overview docs. This parameter enables secure CSRF token enforcement and was introduced in v1.58.6 for v1 and v2.0.0 for v2.

Closes #319

Generated with [Claude Code](https://claude.ai/code)