### PR TITLE
fix: correct v2 environment variable syntax and secret reference documentation

### DIFF
--- a/v2/configuration/overview.mdx
+++ b/v2/configuration/overview.mdx
@@ -38,18 +38,65 @@ The server will check in a few different locations for server configuration (in 
 You can edit any of these properties to your liking, and on restart, Flipt will
 pick up the new changes.
 
-### Environment Substitution
+### Environment Substitution and Secret References
 
-The configuration file also supports environment variable substitution.
+The configuration file supports both environment variable substitution and secret references for managing sensitive data.
 
-This allows you to use environment variables in your configuration file. For example, you can use the `FLIPT_CUSTOM_AUTH_REQUIRED` environment variable in the configuration file like this:
+#### Environment Variables
+
+Environment variables use the `${env:VARIABLE_NAME}` syntax. For example:
 
 ```yaml
 authentication:
-  required: ${FLIPT_CUSTOM_AUTH_REQUIRED}
+  required: ${env:FLIPT_CUSTOM_AUTH_REQUIRED}
+server:
+  http_port: ${env:HTTP_PORT}
 ```
 
-This will replace `${FLIPT_CUSTOM_AUTH_REQUIRED}` with the value of the `FLIPT_CUSTOM_AUTH_REQUIRED` environment variable. The format for environment variable substitution is `${ENV_VAR}`.
+This will replace `${env:FLIPT_CUSTOM_AUTH_REQUIRED}` with the value of the `FLIPT_CUSTOM_AUTH_REQUIRED` environment variable. The format for environment variable substitution is `${env:ENV_VAR}`.
+
+<Warning>
+  v2 uses a different environment variable syntax than v1. The old v1 syntax `${ENV_VAR}` is not supported in v2. You must use the new `${env:ENV_VAR}` format.
+</Warning>
+
+#### Secret References
+
+Secret references use the `${secret:reference}` syntax and integrate with configured secret providers:
+
+```yaml
+authentication:
+  methods:
+    github:
+      client_id: ${env:GITHUB_CLIENT_ID} # Environment variable
+      client_secret: ${secret:github-token} # Secret reference
+    oidc:
+      client_id: ${secret:vault:auth/oidc:client_id} # Vault provider
+      client_secret: ${secret:vault:auth/oidc:client_secret} # Vault provider
+```
+
+Secret references can be:
+
+- **Simple format**: `${secret:key-name}` (uses the default or first configured provider)
+- **Complex format**: `${secret:provider:path:key}` (explicitly specifies provider, path, and key)
+
+#### Mixed Usage
+
+You can combine environment variables and secret references in the same configuration:
+
+```yaml
+server:
+  http_port: ${env:HTTP_PORT} # Environment variable
+  grpc_port: ${env:GRPC_PORT} # Environment variable
+
+authentication:
+  session:
+    csrf:
+      key: ${secret:csrf-key} # Secret reference
+  methods:
+    github:
+      client_id: ${env:GITHUB_CLIENT_ID} # Environment variable
+      client_secret: ${secret:github-token} # Secret reference
+```
 
 <Tip>
   This can be used to provide sensitive information to Flipt without storing it

--- a/v2/configuration/secrets.mdx
+++ b/v2/configuration/secrets.mdx
@@ -149,9 +149,9 @@ vault:
   mount: "secret"
 ```
 
-### Environment Variables
+### Environment Variables for Provider Configuration
 
-Avoid storing sensitive values in configuration files by using environment variables:
+Avoid storing sensitive provider configuration in config files by using environment variables:
 
 ```bash
 export FLIPT_SECRETS_PROVIDERS_VAULT_TOKEN="hvs.your_vault_token"
@@ -159,10 +159,170 @@ export FLIPT_SECRETS_PROVIDERS_VAULT_ROLE_ID="your_role_id"
 export FLIPT_SECRETS_PROVIDERS_VAULT_SECRET_ID="your_secret_id"
 ```
 
-## Using Secrets
+Or reference them using the new v2 environment variable syntax:
 
-<Note>
-  Currently, secrets can only be used with our [Commit
-  Signing](/v2/configuration/commit-signing) feature. We are working on adding
-  support for secrets in general configuration.
-</Note>
+```yaml
+secrets:
+  providers:
+    vault:
+      enabled: true
+      address: ${env:VAULT_ADDR}
+      token: ${env:VAULT_TOKEN}
+      auth_method: "token"
+```
+
+## Using Secrets in Configuration
+
+Secrets can be referenced throughout your Flipt v2 configuration using the `${secret:reference}` syntax. This allows you to keep sensitive values secure while maintaining readable configuration files.
+
+### Reference Formats
+
+#### Simple Format
+
+Use the default or first configured provider:
+
+```yaml
+authentication:
+  session:
+    csrf:
+      key: ${secret:csrf-key}
+  methods:
+    github:
+      client_secret: ${secret:github-token}
+```
+
+#### Complex Format
+
+Explicitly specify the provider, path, and key:
+
+```yaml
+authentication:
+  methods:
+    oidc:
+      client_id: ${secret:vault:auth/oidc:client_id}
+      client_secret: ${secret:vault:auth/oidc:client_secret}
+    github:
+      client_secret: ${secret:file:github-token}
+```
+
+### Complete Configuration Example
+
+Here's a comprehensive example showing secret references with multiple providers:
+
+```yaml
+# Enable multiple secret providers
+secrets:
+  providers:
+    file:
+      enabled: true
+      base_path: "/etc/flipt/secrets"
+    vault:
+      enabled: true
+      address: "https://vault.company.com"
+      auth_method: "kubernetes"
+      role: "flipt-role"
+
+# Use secrets throughout configuration
+server:
+  http_port: ${env:HTTP_PORT} # Environment variable
+  cert_file: ${secret:file:tls-cert} # File provider secret
+  cert_key: ${secret:file:tls-key} # File provider secret
+
+authentication:
+  session:
+    csrf:
+      key: ${secret:vault:auth/csrf:key} # Vault provider secret
+  methods:
+    github:
+      client_id: ${env:GITHUB_CLIENT_ID} # Environment variable
+      client_secret: ${secret:github-token} # Default provider secret
+    oidc:
+      client_id: ${secret:vault:auth/oidc:client_id} # Vault provider
+      client_secret: ${secret:vault:auth/oidc:client_secret} # Vault provider
+
+storage:
+  default:
+    signature:
+      enabled: true
+      key_ref:
+        provider: "vault"
+        path: "signing/gpg"
+        key: "private_key"
+```
+
+### Provider-Specific Examples
+
+#### File Provider Secrets
+
+Create secret files in your configured base path:
+
+```bash
+# /etc/flipt/secrets/secrets.json
+{
+  "data": {
+    "github-token": "ghp_your_github_token",
+    "csrf-key": "your-csrf-secret-key",
+    "tls-cert": "-----BEGIN CERTIFICATE-----...",
+    "tls-key": "-----BEGIN PRIVATE KEY-----..."
+  }
+}
+```
+
+Reference them in configuration:
+
+```yaml
+authentication:
+  session:
+    csrf:
+      key: ${secret:file:csrf-key}
+  methods:
+    github:
+      client_secret: ${secret:file:github-token}
+```
+
+#### HashiCorp Vault Secrets
+
+Store secrets in Vault at specific paths:
+
+```bash
+# Store secrets in Vault
+vault kv put secret/auth/oidc client_id="your-oidc-client-id" client_secret="your-oidc-secret"
+vault kv put secret/auth/csrf key="your-csrf-secret-key"
+```
+
+Reference them in configuration:
+
+```yaml
+authentication:
+  session:
+    csrf:
+      key: ${secret:vault:auth/csrf:key}
+  methods:
+    oidc:
+      client_id: ${secret:vault:auth/oidc:client_id}
+      client_secret: ${secret:vault:auth/oidc:client_secret}
+```
+
+### Combining Environment Variables and Secrets
+
+You can mix environment variables (`${env:VAR}`) and secret references (`${secret:ref}`) in the same configuration:
+
+```yaml
+server:
+  http_port: ${env:HTTP_PORT} # Environment variable
+  https_port: ${env:HTTPS_PORT} # Environment variable
+  cert_file: ${secret:tls-cert} # Secret reference
+  cert_key: ${secret:tls-key} # Secret reference
+
+authentication:
+  required: ${env:AUTH_REQUIRED} # Environment variable
+  session:
+    domain: ${env:SESSION_DOMAIN} # Environment variable
+    csrf:
+      key: ${secret:csrf-key} # Secret reference
+```
+
+<Tip>
+  Use environment variables for non-sensitive configuration values and secret
+  references for sensitive data like API keys, tokens, and certificates.
+</Tip>


### PR DESCRIPTION
Comprehensive fix for v2 environment variable and secret reference documentation based on PR #4505.

## Changes
- Fix environment variable syntax from `${ENV_VAR}` to `${env:ENV_VAR}` in v2 docs
- Update v2/configuration/overview.mdx to use correct `${env:VARIABLE_NAME}` format
- Add warning that v1 syntax is not supported in v2
- Remove secret reference limitation from v2/configuration/secrets.mdx
- Add comprehensive examples for secret references throughout configuration
- Document both simple and complex secret reference formats
- Add examples combining environment variables and secret references

Closes #339

Generated with [Claude Code](https://claude.ai/code)