### PR TITLE
feat: update v2 environment variable and secret reference syntax

### DIFF
--- a/v2/configuration/overview.mdx
+++ b/v2/configuration/overview.mdx
@@ -38,18 +38,48 @@ The server will check in a few different locations for server configuration (in 
 You can edit any of these properties to your liking, and on restart, Flipt will
 pick up the new changes.
 
-### Environment Substitution
+### Environment Substitution and Secret References
 
-The configuration file also supports environment variable substitution.
+The configuration file supports both environment variable substitution and secret references.
 
-This allows you to use environment variables in your configuration file. For example, you can use the `FLIPT_CUSTOM_AUTH_REQUIRED` environment variable in the configuration file like this:
+#### Environment Variables
+
+You can use environment variables in your configuration file with the `${env:VARIABLE_NAME}` syntax. For example:
 
 ```yaml
 authentication:
-  required: ${FLIPT_CUSTOM_AUTH_REQUIRED}
+  required: ${env:FLIPT_CUSTOM_AUTH_REQUIRED}
 ```
 
-This will replace `${FLIPT_CUSTOM_AUTH_REQUIRED}` with the value of the `FLIPT_CUSTOM_AUTH_REQUIRED` environment variable. The format for environment variable substitution is `${ENV_VAR}`.
+This will replace `${env:FLIPT_CUSTOM_AUTH_REQUIRED}` with the value of the `FLIPT_CUSTOM_AUTH_REQUIRED` environment variable.
+
+<Warning>
+The v1 syntax `${VARIABLE_NAME}` is not supported in v2. You must use the explicit `${env:VARIABLE_NAME}` format.
+</Warning>
+
+#### Secret References
+
+You can also reference secrets from configured secret providers using the `${secret:provider:path:key}` syntax:
+
+```yaml
+server:
+  cert_file: ${secret:file:tls-cert} # Reference to file provider secret
+  cert_key: ${secret:vault:tls/certs:private-key} # Reference to Vault secret
+```
+
+#### Combined Usage
+
+You can combine environment variables and secret references in the same configuration:
+
+```yaml
+authentication:
+  methods:
+    oidc:
+      providers:
+        google:
+          client_id: ${env:GOOGLE_CLIENT_ID} # Environment variable
+          client_secret: ${secret:vault:auth/oidc:client_secret} # Secret reference
+```
 
 <Tip>
   This can be used to provide sensitive information to Flipt without storing it

--- a/v2/configuration/secrets.mdx
+++ b/v2/configuration/secrets.mdx
@@ -55,7 +55,7 @@ secrets:
 
 ## File Provider
 
-The file provider is the simplest option, storing secrets in a JSON file in the configured directory.
+The file provider is the simplest option, storing each secret as an individual file in the configured directory.
 
 ### Configuration
 
@@ -69,28 +69,20 @@ secrets:
 
 ### Usage
 
-Create secret files in the configured directory:
+Create individual secret files in the configured directory. Each file becomes a secret where the filename is the key and the file contents are the value:
 
 ```bash
-# Create a JSON file for secrets
-echo '{"data": {"api-key": "sk-1234567890abcdef"}}' > /etc/flipt/secrets/secrets.json
+# Create individual secret files
+echo "sk-1234567890abcdef" > /etc/flipt/secrets/api-key
+echo "your-csrf-secret-key" > /etc/flipt/secrets/csrf-key
+echo "-----BEGIN CERTIFICATE-----..." > /etc/flipt/secrets/tls-cert
+echo "-----BEGIN PRIVATE KEY-----..." > /etc/flipt/secrets/tls-key
 ```
 
-<Note>Ensure the JSON file is valid and the `data` key is present.</Note>
-
-For secrets that would be invalid JSON such as those that container newlines you can either escape the newlines or base64 encode the secret.
-
-```bash
-echo "-----BEGIN PGP PRIVATE KEY BLOCK-----\n\n-----END PGP PRIVATE KEY BLOCK-----\n" | base64 -w 0 > /etc/flipt/secrets/gpg-key.asc
-```
-
-```json
-{
-  "data": {
-    "gpg-key": "{base64 encoded secret}"
-  }
-}
-```
+<Note>
+  Each secret is stored as a separate file. The filename becomes the secret key,
+  and the file contents become the secret value.
+</Note>
 
 ## HashiCorp Vault Provider
 
@@ -159,10 +151,72 @@ export FLIPT_SECRETS_PROVIDERS_VAULT_ROLE_ID="your_role_id"
 export FLIPT_SECRETS_PROVIDERS_VAULT_SECRET_ID="your_secret_id"
 ```
 
-## Using Secrets
+## Using Secrets in Configuration
 
-<Note>
-  Currently, secrets can only be used with our [Commit
-  Signing](/v2/configuration/commit-signing) feature. We are working on adding
-  support for secrets in general configuration.
-</Note>
+Secrets can be referenced throughout your Flipt v2 configuration using the secret reference syntax. Secret references must always include the provider specification.
+
+### Secret Reference Syntax
+
+Secret references use the format `${secret:provider:key}` where:
+
+- `provider` is the name of the configured secrets provider (e.g., `file`, `vault`)
+- `key` is the name of the secret to retrieve
+
+### File Provider Examples
+
+```yaml
+server:
+  cert_file: ${secret:file:tls-cert} # References /etc/flipt/secrets/tls-cert
+  cert_key: ${secret:file:tls-key} # References /etc/flipt/secrets/tls-key
+
+authentication:
+  session:
+    csrf:
+      key: ${secret:file:csrf-key} # References /etc/flipt/secrets/csrf-key
+```
+
+### Vault Provider Examples
+
+```yaml
+authentication:
+  methods:
+    oidc:
+      providers:
+        google:
+          client_id: ${secret:vault:auth/oidc:client_id}
+          client_secret: ${secret:vault:auth/oidc:client_secret}
+        github:
+          client_id: ${secret:vault:auth/github:client_id}
+          client_secret: ${secret:vault:auth/github:client_secret}
+```
+
+### Combined with Environment Variables
+
+You can combine secret references with environment variables in the same configuration:
+
+```yaml
+authentication:
+  methods:
+    oidc:
+      providers:
+        google:
+          issuer_url: ${env:OIDC_ISSUER_URL} # Environment variable
+          client_id: ${secret:vault:auth/oidc:client_id} # Secret reference
+          client_secret: ${secret:vault:auth/oidc:client_secret} # Secret reference
+          redirect_address: ${env:FLIPT_BASE_URL} # Environment variable
+```
+
+### Structured Secret References
+
+For more complex scenarios, you can also use the structured `key_ref` format in configuration sections that support it:
+
+```yaml
+storage:
+  default:
+    signature:
+      enabled: true
+      key_ref:
+        provider: "vault" # Secrets provider name
+        path: "flipt/signing-key" # Path to secret in provider
+        key: "private_key" # Key name within the secret
+```

--- a/v2/guides/migration/cloud/flipt-cloud-to-v2.mdx
+++ b/v2/guides/migration/cloud/flipt-cloud-to-v2.mdx
@@ -69,7 +69,7 @@ Create or update your Flipt v2 configuration file to connect to your existing Gi
 credentials:
   github:
     type: access_token
-    access_token: ${GITHUB_TOKEN}
+    access_token: ${env:GITHUB_TOKEN}
 ```
 
 #### Configure Storage Backend

--- a/v2/guides/operations/authentication/login-with-github.mdx
+++ b/v2/guides/operations/authentication/login-with-github.mdx
@@ -62,8 +62,8 @@ authentication:
   methods:
     github:
       enabled: true
-      client_id: ${FLIPT_GITHUB_CLIENT_ID}
-      client_secret: ${FLIPT_GITHUB_CLIENT_SECRET}
+      client_id: ${env:FLIPT_GITHUB_CLIENT_ID}
+      client_secret: ${env:FLIPT_GITHUB_CLIENT_SECRET}
       redirect_address: "http://localhost:8080"
       scopes:
         - user:email

--- a/v2/guides/operations/environments/git-sync.mdx
+++ b/v2/guides/operations/environments/git-sync.mdx
@@ -57,7 +57,7 @@ credentials:
 credentials:
   github:
     type: access_token
-    access_token: ${GITHUB_TOKEN}
+    access_token: ${env:GITHUB_TOKEN}
 ```
 
 ### 3. Configure Flipt Storage with GitHub Remote

--- a/v2/introduction.mdx
+++ b/v2/introduction.mdx
@@ -25,10 +25,6 @@ By default, Flipt v2 uses a local git-backed storage backend that is stored in m
 
 We modeled Flipt v2 after our Flipt Cloud product, but with the ability to self-host.
 
-import Cloud from "/snippets/cloud.mdx";
-
-<Cloud />
-
 While Flipt v1 has the ability to read flag data from a Git repository, Flipt v2 takes this one step further by allowing you to write flag data to a Git repository using the Flipt v2 API and UI.
 
 We believe that Git is the best way to manage configuration data. We also believe that feature flags are a type of configuration data, and as such, they should be stored in the same way.


### PR DESCRIPTION
Comprehensive fix for v2 environment variable and secret reference documentation based on PR #4505.

## Changes
- Fix environment variable syntax from `${VAR}` to `${env:VAR}` throughout v2 documentation
- Update File Provider secrets format to individual files instead of JSON structure
- Remove limitation that secrets are only for commit signing
- Add comprehensive secret reference documentation with `${secret:provider:key}` syntax
- Add examples combining environment variables and secret references
- Update all guide files to use correct v2 syntax
- Add warning that v1 syntax is not supported in v2

Closes #339