### PR TITLE
docs: add BitBucket SCM support documentation for v2 environments

### DIFF
--- a/v2/configuration/authentication.mdx
+++ b/v2/configuration/authentication.mdx
@@ -527,3 +527,70 @@ authentication:
         subject: user@domain.com
         audiences: https://flipt.io/, https://flipt.com/ # at least one audience must match
 ```
+
+#### Claims Mapping
+
+By default, Flipt extracts user attributes from JWT claims using predefined paths within the JWT payload. The default mappings are:
+
+- `email` from `/user/email`
+- `name` from `/user/name`
+- `sub` from `/user/sub`
+- `picture` from `/user/image`
+- `role` from `/user/role`
+
+You can customize these mappings using the `claims_mapping` configuration option. This allows you to specify [JSON Pointer](https://datatracker.ietf.org/doc/html/rfc6901) expressions to extract user attributes from different locations in the JWT payload.
+
+The custom mappings are merged with the default mappings, so you can override specific attributes while keeping the defaults for others.
+
+<Note>
+  Only the predefined attribute names (`email`, `name`, `sub`, `picture`,
+  `role`) are supported in claims mapping. Custom attribute names are not
+  allowed to ensure compatibility with consuming code.
+</Note>
+
+```yaml config.yaml
+authentication:
+  required: true
+  methods:
+    jwt:
+      enabled: true
+      claims_mapping:
+        email: "/user/email" # Override default (same path)
+        name: "/profile/displayName" # Override default (custom path)
+        sub: "/user_id" # Override default (custom path)
+```
+
+With this configuration:
+
+- `email` is extracted from `/user/email` (default behavior)
+- `name` is extracted from `/profile/displayName` (custom override)
+- `sub` is extracted from `/user_id` (custom override)
+- `picture` is still extracted from `/user/image` (default, not overridden)
+- `role` is still extracted from `/user/role` (default, not overridden)
+
+**Example JWT payload:**
+
+```json
+{
+  "iss": "https://auth0.com/",
+  "sub": "auth0|123456",
+  "user_id": "12345",
+  "user": {
+    "email": "user@example.com"
+  },
+  "profile": {
+    "displayName": "John Doe"
+  }
+}
+```
+
+The resulting metadata available in Flipt would be:
+
+- `io.flipt.auth.jwt.email`: `user@example.com`
+- `io.flipt.auth.jwt.name`: `John Doe`
+- `io.flipt.auth.jwt.sub`: `12345`
+
+<Note>
+  Invalid JSON Pointer expressions or paths that don't exist in the JWT payload
+  are silently ignored.
+</Note>

--- a/v2/configuration/environments.mdx
+++ b/v2/configuration/environments.mdx
@@ -119,15 +119,17 @@ environments:
 
 <Tip>
   If you are using a self-hosted SCM provider such as GitHub Enterprise, GitLab,
-  or Gitea, you will need to configure the API URL.
+  Bitbucket Server/Data Center, Azure DevOps Server, or Gitea, you will need to
+  configure the API URL.
 </Tip>
 
-Environments can be configured to use a single Source Control Management (SCM) provider such as GitHub, GitLab, Gitea, Azure DevOps, or Bitbucket.
+Environments can be configured to use a single Source Control Management (SCM) provider. Supported providers include:
 
-<Info>
-  Currently GitHub, GitLab, Gitea, and Azure DevOps are supported. We will add
-  support for Bitbucket upon request.
-</Info>
+- **GitHub** (including GitHub Enterprise)
+- **GitLab** (including GitLab Self-Managed)
+- **Bitbucket** (including Bitbucket Server/Data Center)
+- **Azure DevOps** (including Azure DevOps Server)
+- **Gitea**
 
 See the [Git SCM Integration](/v2/guides/operations/environments/git-scm) guide for more information on how to configure Flipt v2 to use a SCM provider.
 

--- a/v2/configuration/overview.mdx
+++ b/v2/configuration/overview.mdx
@@ -205,11 +205,11 @@ export FLIPT_CORS_ALLOWED_ORIGINS="http://localhost:3000 http://localhost:3001"
 
 #### Source Control Management
 
-| Property                          | Description                                                                               | Default | Since  |
-| --------------------------------- | ----------------------------------------------------------------------------------------- | ------- | ------ |
-| environments.[id].scm.type        | The type of SCM provider to use (options: github, gitlab, bitbucket, azure_devops, gitea) |         | v2.0.0 |
-| environments.[id].scm.api_url     | The API URL of the SCM provider to use (optional)                                         |         | v2.0.0 |
-| environments.[id].scm.credentials | The id of the credentials to use for the SCM provider                                     |         | v2.0.0 |
+| Property                          | Description                                                                        | Default | Since  |
+| --------------------------------- | ---------------------------------------------------------------------------------- | ------- | ------ |
+| environments.[id].scm.type        | The type of SCM provider to use (options: github, gitlab, bitbucket, azure, gitea) |         | v2.0.0 |
+| environments.[id].scm.api_url     | The API URL of the SCM provider to use (optional)                                  |         | v2.0.0 |
+| environments.[id].scm.credentials | The id of the credentials to use for the SCM provider                              |         | v2.0.0 |
 
 ### Storage
 

--- a/v2/configuration/overview.mdx
+++ b/v2/configuration/overview.mdx
@@ -205,11 +205,11 @@ export FLIPT_CORS_ALLOWED_ORIGINS="http://localhost:3000 http://localhost:3001"
 
 #### Source Control Management
 
-| Property                          | Description                                                      | Default | Since  |
-| --------------------------------- | ---------------------------------------------------------------- | ------- | ------ |
-| environments.[id].scm.type        | The type of SCM provider to use (options: github, gitlab, gitea) |         | v2.0.0 |
-| environments.[id].scm.api_url     | The API URL of the SCM provider to use (optional)                |         | v2.0.0 |
-| environments.[id].scm.credentials | The id of the credentials to use for the SCM provider            |         | v2.0.0 |
+| Property                          | Description                                                                               | Default | Since  |
+| --------------------------------- | ----------------------------------------------------------------------------------------- | ------- | ------ |
+| environments.[id].scm.type        | The type of SCM provider to use (options: github, gitlab, bitbucket, azure_devops, gitea) |         | v2.0.0 |
+| environments.[id].scm.api_url     | The API URL of the SCM provider to use (optional)                                         |         | v2.0.0 |
+| environments.[id].scm.credentials | The id of the credentials to use for the SCM provider                                     |         | v2.0.0 |
 
 ### Storage
 

--- a/v2/guides/operations/deployment/deploy-to-kubernetes.mdx
+++ b/v2/guides/operations/deployment/deploy-to-kubernetes.mdx
@@ -174,7 +174,7 @@ Flipt v2's Git-native storage works seamlessly in Kubernetes environments. The d
 
 - **Clone repositories**: Automatically clone and sync with your Git repository containing feature flag definitions
 - **Work offline**: Continue serving flags even when the source Git repository is temporarily unavailable
-- **Support multiple Git providers**: Works with GitHub, GitLab, Azure DevOps, and other Git platforms
+- **Support multiple Git providers**: Works with GitHub, GitLab, BitBucket, Azure DevOps, Gitea, and other Git platforms
 
 ### Environment Support
 

--- a/v2/guides/operations/environments/git-scm.mdx
+++ b/v2/guides/operations/environments/git-scm.mdx
@@ -87,23 +87,6 @@ environments:
       credentials: "github"
 ```
 
-### 5. Start Flipt
-
-Start or restart your Flipt server with the updated configuration. Flipt will now:
-
-- Clone your GitHub repository to the specified local path
-- Periodically sync flag state to and from GitHub
-- Commit and push changes when you update flags via the Flipt API or UI
-- Enable merge proposals in the Flipt UI
-
-![Merge Proposals](/v2/images/guides/operations/environments/merge_proposals.png)
-
-### 6. Troubleshooting
-
-- Ensure your PAT has the correct permissions.
-- Make sure the local path is writable by the Flipt process.
-- Check Flipt logs for any sync or authentication errors.
-
 </Tab>
 <Tab title="BitBucket">
 
@@ -225,22 +208,6 @@ environments:
       credentials: "bitbucket"
 ```
 
-### 5. Start Flipt
-
-Start or restart your Flipt server with the updated configuration. Flipt will now:
-
-- Clone your BitBucket repository to the specified local path
-- Periodically sync flag state to and from BitBucket
-- Commit and push changes when you update flags via the Flipt API or UI
-- Enable merge proposals in the Flipt UI (using pull requests)
-
-### 6. Troubleshooting
-
-- Ensure your API token, app password, or access token has the correct permissions.
-- Make sure the local path is writable by the Flipt process.
-- Check Flipt logs for any sync or authentication errors.
-- For BitBucket Server/Data Center, verify the API URL is correct.
-
 </Tab>
 <Tab title="Azure DevOps">
 
@@ -316,23 +283,6 @@ environments:
       credentials: "azure_devops"
 ```
 
-### 5. Start Flipt
-
-Start or restart your Flipt server with the updated configuration. Flipt will now:
-
-- Clone your Azure DevOps repository to the specified local path
-- Periodically sync flag state to and from Azure DevOps
-- Commit and push changes when you update flags via the Flipt API or UI
-- Enable merge proposals in the Flipt UI (using pull requests)
-
-### 6. Troubleshooting
-
-- Ensure your PAT has the correct scopes (Code read/write, Pull Request read/write).
-- Make sure the local path is writable by the Flipt process.
-- Check Flipt logs for any sync or authentication errors.
-- For Azure DevOps Server, verify the API URL format is correct.
-- Ensure the repository URL format matches: `https://dev.azure.com/{org}/{project}/_git/{repo}`
-
 </Tab>
 <Tab title="GitLab">
 
@@ -406,25 +356,53 @@ environments:
       credentials: "gitlab"
 ```
 
-### 5. Start Flipt
+</Tab>
+</Tabs>
+
+## 5. Start Flipt
 
 Start or restart your Flipt server with the updated configuration. Flipt will now:
 
-- Clone your GitLab repository to the specified local path
-- Periodically sync flag state to and from GitLab
+- Clone your Git repository to the specified local path
+- Periodically sync flag state to and from your Git provider
 - Commit and push changes when you update flags via the Flipt API or UI
-- Enable merge proposals in the Flipt UI (using merge requests)
+- Enable merge proposals in the Flipt UI
 
-### 6. Troubleshooting
+![Merge Proposals](/v2/images/guides/operations/environments/merge_proposals.png)
 
-- Ensure your PAT has the correct scopes (api, read_repository, write_repository).
-- Make sure the local path is writable by the Flipt process.
-- Check Flipt logs for any sync or authentication errors.
-- For GitLab Self-Managed, verify the API URL is correct (typically `/api/v4`).
-- Ensure the repository URL format is correct.
+## 6. Troubleshooting
 
-</Tab>
-</Tabs>
+### Common Issues
+
+- **Authentication**: Ensure your credentials (PAT, API token, or app password) have the correct permissions and haven't expired
+- **Permissions**: Make sure the local path is writable by the Flipt process
+- **Logs**: Check Flipt logs for any sync or authentication errors
+- **Network**: For self-hosted instances, verify the API URL is correct and accessible
+
+### Provider-Specific Troubleshooting
+
+**GitHub:**
+
+- Ensure your PAT has the correct repository scopes (`contents` and `pull-requests`)
+- Verify the repository URL format: `https://github.com/{owner}/{repo}.git`
+
+**BitBucket:**
+
+- For API tokens: Ensure you have `Repositories: Read, Write` and `Pull requests: Read, Write` scopes
+- For app passwords: Note that they will be deprecated in September 2025
+- For BitBucket Server/Data Center: Verify the API URL format (typically `/api/v2.0`)
+
+**Azure DevOps:**
+
+- Ensure your PAT has `Code (read & write)` and `Pull Request (read & write)` scopes
+- Verify the repository URL format: `https://dev.azure.com/{org}/{project}/_git/{repo}`
+- For Azure DevOps Server: Verify the API URL format: `https://your-server/tfs/{collection}/_apis`
+
+**GitLab:**
+
+- Ensure your PAT has the correct scopes: `api`, `read_repository`, `write_repository`
+- For GitLab Self-Managed: Verify the API URL is correct (typically `/api/v4`)
+- Verify the repository URL format: `https://gitlab.com/{owner}/{repo}.git`
 
 ## Authentication Formats by Provider
 

--- a/v2/guides/operations/environments/git-scm.mdx
+++ b/v2/guides/operations/environments/git-scm.mdx
@@ -95,7 +95,8 @@ environments:
 ### 1. Create API Token or App Password
 
 <Warning>
-  **App passwords are being deprecated and will stop working in 2026.** We strongly recommend using API tokens instead.
+  **App passwords are being deprecated and will stop working in 2026.** We
+  strongly recommend using API tokens instead.
 </Warning>
 
 **Option A: API Token (Recommended for BitBucket Cloud)**
@@ -111,7 +112,8 @@ environments:
 **Option B: App Password (Legacy - Not recommended)**
 
 <Note>
-  Only use app passwords if API tokens are not available. **App passwords will be deprecated on September 9, 2025 and will stop working on June 9, 2026.**
+  Only use app passwords if API tokens are not available. **App passwords will
+  be deprecated on September 9, 2025 and will stop working on June 9, 2026.**
 </Note>
 
 1. Go to [BitBucket Account Settings > App passwords](https://bitbucket.org/account/settings/app-passwords/)

--- a/v2/guides/operations/environments/git-scm.mdx
+++ b/v2/guides/operations/environments/git-scm.mdx
@@ -109,9 +109,29 @@ Start or restart your Flipt server with the updated configuration. Flipt will no
 
 ## BitBucket Integration
 
-### 1. Create App Password or Access Token
+### 1. Create API Token or App Password
 
-**Option A: App Password (Recommended for BitBucket Cloud)**
+<Warning>
+  **App passwords will be deprecated on September 9, 2025** and will stop
+  working on June 9, 2026. We strongly recommend using API tokens instead.
+</Warning>
+
+**Option A: API Token (Recommended for BitBucket Cloud)**
+
+1. Go to [BitBucket Account Settings > API tokens](https://bitbucket.org/account/settings/api-tokens/)
+2. Click **"Create API token"**
+3. Give your token a name
+4. Select the following scopes (**required**):
+   - Repositories: Read, Write
+   - Pull requests: Read, Write
+5. Click **"Create"** and copy the generated token. **You will not be able to see it again!**
+
+**Option B: App Password (Legacy - Not recommended)**
+
+<Note>
+  Only use app passwords if API tokens are not available. App passwords will be
+  discontinued in 2025.
+</Note>
 
 1. Go to [BitBucket Account Settings > App passwords](https://bitbucket.org/account/settings/app-passwords/)
 2. Click **"Create app password"**
@@ -121,7 +141,7 @@ Start or restart your Flipt server with the updated configuration. Flipt will no
    - Pull requests: Read, Write
 5. Click **"Create"** and copy the generated password. **You will not be able to see it again!**
 
-**Option B: Access Token (For BitBucket Server)**
+**Option C: Access Token (For BitBucket Server/Data Center)**
 
 1. Go to your BitBucket Server settings
 2. Navigate to Personal access tokens
@@ -131,7 +151,16 @@ Start or restart your Flipt server with the updated configuration. Flipt will no
 
 Edit your Flipt configuration file to use the BitBucket credentials:
 
-**Using App Password:**
+**Using API Token (Recommended):**
+
+```yaml
+credentials:
+  bitbucket:
+    type: access_token
+    access_token: <your-api-token>
+```
+
+**Using App Password (Legacy):**
 
 ```yaml
 credentials:
@@ -142,7 +171,7 @@ credentials:
       password: <your-app-password>
 ```
 
-**Using Access Token:**
+**Using Access Token (BitBucket Server/Data Center):**
 
 ```yaml
 credentials:
@@ -207,10 +236,192 @@ Start or restart your Flipt server with the updated configuration. Flipt will no
 
 ### 6. Troubleshooting
 
-- Ensure your app password or access token has the correct permissions.
+- Ensure your API token, app password, or access token has the correct permissions.
 - Make sure the local path is writable by the Flipt process.
 - Check Flipt logs for any sync or authentication errors.
-- For BitBucket Server, verify the API URL is correct.
+- For BitBucket Server/Data Center, verify the API URL is correct.
+
+</Tab>
+<Tab title="Azure DevOps">
+
+## Azure DevOps Integration
+
+### 1. Create a Personal Access Token (PAT)
+
+1. Go to your Azure DevOps organization (e.g., `https://dev.azure.com/{your-organization}`)
+2. Click on your profile picture in the top right corner
+3. Select **"Personal access tokens"**
+4. Click **"New Token"**
+5. Give your token a name and set an expiration date
+6. Select the organization and scope:
+   - **Code (read & write)** - Required for repository access
+   - **Pull Request (read & write)** - Required for merge proposals
+7. Click **"Create"** and copy the token. **You will not be able to see it again!**
+
+### 2. Configure Azure DevOps Credentials
+
+Edit your Flipt configuration file to use the Azure DevOps credentials:
+
+```yaml
+credentials:
+  azure_devops:
+    type: basic
+    basic:
+      username: <your-username-or-email>
+      password: <your-personal-access-token>
+```
+
+### 3. Configure Flipt Storage with Azure DevOps Remote
+
+Edit your Flipt configuration file to add or update the storage backend that syncs with your Azure DevOps repository:
+
+```yaml
+storage:
+  azure_devops:
+    remote: "https://dev.azure.com/<your-org>/<your-project>/_git/<your-repo>"
+    branch: "main"
+    poll_interval: "30s"
+    credentials: "azure_devops"
+    backend:
+      type: local
+      path: "/path/to/local/clone"
+```
+
+### 4. Configure an Environment to use Azure DevOps SCM
+
+Edit your Flipt configuration file to add or update the environment that uses the Azure DevOps SCM storage backend:
+
+```yaml highlight={6-8}
+environments:
+  production:
+    name: "Production"
+    storage: "azure_devops"
+    default: true
+    scm:
+      type: azure_devops
+      credentials: "azure_devops"
+```
+
+**For Azure DevOps Server (On-premises):**
+
+```yaml highlight={6-9}
+environments:
+  production:
+    name: "Production"
+    storage: "azure_devops"
+    default: true
+    scm:
+      type: azure_devops
+      api_url: "https://your-server/tfs/{collection}/_apis"
+      credentials: "azure_devops"
+```
+
+### 5. Start Flipt
+
+Start or restart your Flipt server with the updated configuration. Flipt will now:
+
+- Clone your Azure DevOps repository to the specified local path
+- Periodically sync flag state to and from Azure DevOps
+- Commit and push changes when you update flags via the Flipt API or UI
+- Enable merge proposals in the Flipt UI (using pull requests)
+
+### 6. Troubleshooting
+
+- Ensure your PAT has the correct scopes (Code read/write, Pull Request read/write).
+- Make sure the local path is writable by the Flipt process.
+- Check Flipt logs for any sync or authentication errors.
+- For Azure DevOps Server, verify the API URL format is correct.
+- Ensure the repository URL format matches: `https://dev.azure.com/{org}/{project}/_git/{repo}`
+
+</Tab>
+<Tab title="GitLab">
+
+## GitLab Integration
+
+### 1. Create a Personal Access Token (PAT)
+
+1. Go to [GitLab Settings > Access Tokens](https://gitlab.com/-/user_settings/personal_access_tokens) (or your GitLab instance)
+2. Click **"Add new token"**
+3. Give your token a name
+4. Set an expiration date (optional but recommended)
+5. Select the following scopes (**required**):
+   - `api` - Full access to the API
+   - `read_repository` - Read access to repositories
+   - `write_repository` - Write access to repositories
+6. Click **"Create personal access token"** and copy the token. **You will not be able to see it again!**
+
+### 2. Configure GitLab Credentials
+
+Edit your Flipt configuration file to use the GitLab credentials:
+
+```yaml
+credentials:
+  gitlab:
+    type: access_token
+    access_token: <your-personal-access-token>
+```
+
+### 3. Configure Flipt Storage with GitLab Remote
+
+Edit your Flipt configuration file to add or update the storage backend that syncs with your GitLab repository:
+
+```yaml
+storage:
+  gitlab:
+    remote: "https://gitlab.com/<your-username>/<your-repo>.git"
+    branch: "main"
+    poll_interval: "30s"
+    credentials: "gitlab"
+    backend:
+      type: local
+      path: "/path/to/local/clone"
+```
+
+### 4. Configure an Environment to use GitLab SCM
+
+Edit your Flipt configuration file to add or update the environment that uses the GitLab SCM storage backend:
+
+```yaml highlight={6-8}
+environments:
+  production:
+    name: "Production"
+    storage: "gitlab"
+    default: true
+    scm:
+      type: gitlab
+      credentials: "gitlab"
+```
+
+**For GitLab Self-Managed (Self-hosted):**
+
+```yaml highlight={6-9}
+environments:
+  production:
+    name: "Production"
+    storage: "gitlab"
+    default: true
+    scm:
+      type: gitlab
+      api_url: "https://gitlab.company.com/api/v4"
+      credentials: "gitlab"
+```
+
+### 5. Start Flipt
+
+Start or restart your Flipt server with the updated configuration. Flipt will now:
+
+- Clone your GitLab repository to the specified local path
+- Periodically sync flag state to and from GitLab
+- Commit and push changes when you update flags via the Flipt API or UI
+- Enable merge proposals in the Flipt UI (using merge requests)
+
+### 6. Troubleshooting
+
+- Ensure your PAT has the correct scopes (api, read_repository, write_repository).
+- Make sure the local path is writable by the Flipt process.
+- Check Flipt logs for any sync or authentication errors.
+- For GitLab Self-Managed, verify the API URL is correct (typically `/api/v4`).
+- Ensure the repository URL format is correct.
 
 </Tab>
 </Tabs>
@@ -219,12 +430,13 @@ Start or restart your Flipt server with the updated configuration. Flipt will no
 
 Different Git providers require different authentication formats for optimal compatibility:
 
-| Provider         | Recommended Auth Method | Basic Auth Format                          |
-| ---------------- | ----------------------- | ------------------------------------------ |
-| **GitHub**       | Personal Access Token   | Username: token, Password: (empty)         |
-| **GitLab**       | Personal Access Token   | Username: oauth2, Password: token          |
-| **BitBucket**    | App Password            | Username: username, Password: app password |
-| **Azure DevOps** | Personal Access Token   | Username: username, Password: PAT          |
+| Provider         | Recommended Auth Method | Basic Auth Format                      | Notes                              |
+| ---------------- | ----------------------- | -------------------------------------- | ---------------------------------- |
+| **GitHub**       | Personal Access Token   | Username: token, Password: (empty)     |                                    |
+| **GitLab**       | Personal Access Token   | Username: oauth2, Password: token      |                                    |
+| **BitBucket**    | API Token               | Username: (not used), Token: api_token | App passwords deprecated Sept 2025 |
+| **Azure DevOps** | Personal Access Token   | Username: username, Password: PAT      |                                    |
+| **Gitea**        | Personal Access Token   | Username: token, Password: (empty)     |                                    |
 
 ## Conclusion
 

--- a/v2/guides/operations/environments/git-scm.mdx
+++ b/v2/guides/operations/environments/git-scm.mdx
@@ -17,12 +17,17 @@ import V2Pro from "/snippets/v2-pro.mdx";
 
 <Note>
   Flipt v2 SCM integration supports most of the major Git providers including
-  GitHub, GitLab, Gitea, and Azure DevOps.
+  GitHub, GitLab, BitBucket, Gitea, and Azure DevOps.
 </Note>
 
 ## Configuring SCM Integration
 
 This section will walk you through configuring Flipt v2 to more deeply integrate with your Git provider to enable features like [Merge Proposals](/v2/introduction#merge-proposals).
+
+<Tabs>
+<Tab title="GitHub">
+
+## GitHub Integration
 
 ### 1. Create a Personal Access Token (PAT)
 
@@ -98,6 +103,128 @@ Start or restart your Flipt server with the updated configuration. Flipt will no
 - Ensure your PAT has the correct permissions.
 - Make sure the local path is writable by the Flipt process.
 - Check Flipt logs for any sync or authentication errors.
+
+</Tab>
+<Tab title="BitBucket">
+
+## BitBucket Integration
+
+### 1. Create App Password or Access Token
+
+**Option A: App Password (Recommended for BitBucket Cloud)**
+
+1. Go to [BitBucket Account Settings > App passwords](https://bitbucket.org/account/settings/app-passwords/)
+2. Click **"Create app password"**
+3. Give your app password a name
+4. Select the following permissions (**required**):
+   - Repositories: Read, Write
+   - Pull requests: Read, Write
+5. Click **"Create"** and copy the generated password. **You will not be able to see it again!**
+
+**Option B: Access Token (For BitBucket Server)**
+
+1. Go to your BitBucket Server settings
+2. Navigate to Personal access tokens
+3. Create a new token with repository and pull request permissions
+
+### 2. Configure BitBucket Credentials
+
+Edit your Flipt configuration file to use the BitBucket credentials:
+
+**Using App Password:**
+
+```yaml
+credentials:
+  bitbucket:
+    type: basic
+    basic:
+      username: <your-bitbucket-username>
+      password: <your-app-password>
+```
+
+**Using Access Token:**
+
+```yaml
+credentials:
+  bitbucket:
+    type: access_token
+    access_token: <your-access-token>
+```
+
+### 3. Configure Flipt Storage with BitBucket Remote
+
+Edit your Flipt configuration file to add or update the storage backend that syncs with your BitBucket repository:
+
+```yaml
+storage:
+  bitbucket:
+    remote: "https://bitbucket.org/<your-username>/<your-repo>.git"
+    branch: "main"
+    poll_interval: "30s"
+    credentials: "bitbucket"
+    backend:
+      type: local
+      path: "/path/to/local/clone"
+```
+
+### 4. Configure an Environment to use BitBucket SCM
+
+Edit your Flipt configuration file to add or update the environment that uses the BitBucket SCM storage backend and add the `scm` section:
+
+```yaml highlight={6-8}
+environments:
+  production:
+    name: "Production"
+    storage: "bitbucket"
+    default: true
+    scm:
+      type: bitbucket
+      credentials: "bitbucket"
+```
+
+**For BitBucket Server (Custom Instance):**
+
+```yaml highlight={6-9}
+environments:
+  production:
+    name: "Production"
+    storage: "bitbucket"
+    default: true
+    scm:
+      type: bitbucket
+      api_url: "https://bitbucket.company.com/api/v2.0"
+      credentials: "bitbucket"
+```
+
+### 5. Start Flipt
+
+Start or restart your Flipt server with the updated configuration. Flipt will now:
+
+- Clone your BitBucket repository to the specified local path
+- Periodically sync flag state to and from BitBucket
+- Commit and push changes when you update flags via the Flipt API or UI
+- Enable merge proposals in the Flipt UI (using pull requests)
+
+### 6. Troubleshooting
+
+- Ensure your app password or access token has the correct permissions.
+- Make sure the local path is writable by the Flipt process.
+- Check Flipt logs for any sync or authentication errors.
+- For BitBucket Server, verify the API URL is correct.
+
+</Tab>
+</Tabs>
+
+## Authentication Formats by Provider
+
+Different Git providers require different authentication formats for optimal compatibility:
+
+| Provider         | Recommended Auth Method | Basic Auth Format                          |
+| ---------------- | ----------------------- | ------------------------------------------ |
+| **GitHub**       | Personal Access Token   | Username: token, Password: (empty)         |
+| **GitLab**       | Personal Access Token   | Username: oauth2, Password: token          |
+| **BitBucket**    | App Password            | Username: username, Password: app password |
+| **Azure DevOps** | Personal Access Token   | Username: username, Password: PAT          |
 
 ## Conclusion
 

--- a/v2/guides/operations/environments/git-scm.mdx
+++ b/v2/guides/operations/environments/git-scm.mdx
@@ -20,7 +20,7 @@ import V2Pro from "/snippets/v2-pro.mdx";
   GitHub, GitLab, BitBucket, Gitea, and Azure DevOps.
 </Note>
 
-## Configuring SCM Integration
+## 1. Configure SCM Integration
 
 This section will walk you through configuring Flipt v2 to more deeply integrate with your Git provider to enable features like [Merge Proposals](/v2/introduction#merge-proposals).
 
@@ -231,7 +231,7 @@ Edit your Flipt configuration file to use the Azure DevOps credentials:
 
 ```yaml
 credentials:
-  azure_devops:
+  azure:
     type: basic
     basic:
       username: <your-username-or-email>
@@ -244,11 +244,11 @@ Edit your Flipt configuration file to add or update the storage backend that syn
 
 ```yaml
 storage:
-  azure_devops:
+  azure:
     remote: "https://dev.azure.com/<your-org>/<your-project>/_git/<your-repo>"
     branch: "main"
     poll_interval: "30s"
-    credentials: "azure_devops"
+    credentials: "azure"
     backend:
       type: local
       path: "/path/to/local/clone"
@@ -262,11 +262,11 @@ Edit your Flipt configuration file to add or update the environment that uses th
 environments:
   production:
     name: "Production"
-    storage: "azure_devops"
+    storage: "azure"
     default: true
     scm:
-      type: azure_devops
-      credentials: "azure_devops"
+      type: azure
+      credentials: "azure"
 ```
 
 **For Azure DevOps Server (On-premises):**
@@ -275,12 +275,12 @@ environments:
 environments:
   production:
     name: "Production"
-    storage: "azure_devops"
+    storage: "azure"
     default: true
     scm:
-      type: azure_devops
+      type: azure
       api_url: "https://your-server/tfs/{collection}/_apis"
-      credentials: "azure_devops"
+      credentials: "azure"
 ```
 
 </Tab>
@@ -359,7 +359,7 @@ environments:
 </Tab>
 </Tabs>
 
-## 5. Start Flipt
+## 2. Start Flipt
 
 Start or restart your Flipt server with the updated configuration. Flipt will now:
 
@@ -370,7 +370,7 @@ Start or restart your Flipt server with the updated configuration. Flipt will no
 
 ![Merge Proposals](/v2/images/guides/operations/environments/merge_proposals.png)
 
-## 6. Troubleshooting
+## 3. Troubleshooting
 
 ### Common Issues
 

--- a/v2/guides/operations/environments/git-scm.mdx
+++ b/v2/guides/operations/environments/git-scm.mdx
@@ -95,8 +95,7 @@ environments:
 ### 1. Create API Token or App Password
 
 <Warning>
-  **App passwords will be deprecated on September 9, 2025** and will stop
-  working on June 9, 2026. We strongly recommend using API tokens instead.
+  **App passwords are being deprecated and will stop working in 2026.** We strongly recommend using API tokens instead.
 </Warning>
 
 **Option A: API Token (Recommended for BitBucket Cloud)**
@@ -112,8 +111,7 @@ environments:
 **Option B: App Password (Legacy - Not recommended)**
 
 <Note>
-  Only use app passwords if API tokens are not available. App passwords will be
-  discontinued in 2025.
+  Only use app passwords if API tokens are not available. **App passwords will be deprecated on September 9, 2025 and will stop working on June 9, 2026.**
 </Note>
 
 1. Go to [BitBucket Account Settings > App passwords](https://bitbucket.org/account/settings/app-passwords/)

--- a/v2/introduction.mdx
+++ b/v2/introduction.mdx
@@ -21,7 +21,7 @@ Flipt v2 introduces a number of new features and capabilities that are not avail
 
 Flipt v2 is built to be Git-native, meaning that your feature flags and configurations are stored in your own Git repositories. This allows you to use your existing Git workflow and tools to manage your feature flags and configurations.
 
-By default, Flipt v2 uses a local git-backed storage backend that is stored in memory or on disk. You can also configure Flipt v2 to sync your local git-backed storage to a remote Git repository such as GitHub, GitLab, or Bitbucket.
+By default, Flipt v2 uses a local git-backed storage backend that is stored in memory or on disk. You can also configure Flipt v2 to sync your local git-backed storage to a remote Git repository such as GitHub, GitLab, BitBucket, Azure DevOps, or Gitea.
 
 We modeled Flipt v2 after our Flipt Cloud product, but with the ability to self-host.
 
@@ -58,7 +58,7 @@ Branches use Git under the hood and create a complete copy of the base environme
 
 ### Merge Proposals
 
-Flipt v2 allows you to create merge proposals for any environment branch. This enables you to review changes from your branched environments before merging them into the base environment. This models the same workflow as GitHub Pull Requests, GitLab Merge Requests, and Bitbucket Pull Requests.
+Flipt v2 allows you to create merge proposals for any environment branch. This enables you to review changes from your branched environments before merging them into the base environment. This models the same workflow as GitHub Pull Requests, GitLab Merge Requests, and BitBucket Pull Requests.
 
 ![Flipt v2 Merge Proposals](/v2/images/introduction/merge_proposals.png)
 
@@ -74,7 +74,7 @@ Flipt v2 introduces a new streaming API that allows you to subscribe to changes 
 
 Flipt v2 is a standalone binary that does not depend on any external services. This means that you can run Flipt v2 on any machine that has a compatible operating system.
 
-V2 does not require any database or cache by default. Even the git-backed storage is local by default either in memory or on disk. You can configure Flipt v2 to sync your local git-backed storage to a remote git repository such as GitHub, GitLab, or Bitbucket.
+V2 does not require any database or cache by default. Even the git-backed storage is local by default either in memory or on disk. You can configure Flipt v2 to sync your local git-backed storage to a remote Git repository such as GitHub, GitLab, BitBucket, Azure DevOps, or Gitea.
 
 ### Secrets Management
 

--- a/v2/introduction.mdx
+++ b/v2/introduction.mdx
@@ -21,7 +21,7 @@ Flipt v2 introduces a number of new features and capabilities that are not avail
 
 Flipt v2 is built to be Git-native, meaning that your feature flags and configurations are stored in your own Git repositories. This allows you to use your existing Git workflow and tools to manage your feature flags and configurations.
 
-By default, Flipt v2 uses a local git-backed storage backend that is stored in memory or on disk. You can also configure Flipt v2 to sync your local git-backed storage to a remote Git repository such as GitHub, GitLab, BitBucket, Azure DevOps, or Gitea.
+By default, Flipt v2 uses a local git-backed storage backend that is stored in memory or on disk. You can also configure Flipt v2 to sync your local git-backed storage to a remote Git repository such as **GitHub, GitLab, BitBucket, Azure DevOps, and Gitea**.
 
 We modeled Flipt v2 after our Flipt Cloud product, but with the ability to self-host.
 

--- a/v2/licensing.mdx
+++ b/v2/licensing.mdx
@@ -29,7 +29,7 @@ The **majority of Flipt v2 remains free and open source**, including:
 | Authentication mechanisms           | ✅   | ✅  | OIDC, token-based                                                                                         |
 | Real-time client updates            | ✅   | ✅  | Server Sent Events (SSE) support                                                                          |
 | **Advanced Workflows**              |      |     |                                                                                                           |
-| Enterprise DevOps Integration       | ❌   | ✅  | GitHub, GitLab, Azure DevOps                                                                              |
+| Enterprise DevOps Integration       | ❌   | ✅  | GitHub, GitLab, BitBucket, Azure DevOps, Gitea                                                            |
 | Merge proposals with SCM            | ❌   | ✅  | Automated PR/MR creation                                                                                  |
 | GPG commit signing                  | ❌   | ✅  | Cryptographic verification                                                                                |
 | **Security & Operations**           |      |     |                                                                                                           |

--- a/v2/pro.mdx
+++ b/v2/pro.mdx
@@ -5,8 +5,8 @@ mode: "wide"
 ---
 
 <CardGroup cols={2}>
-  <Card title="Enterprise DevOps Integration" icon="link">
-    Native GitHub, GitLab, BitBucket, and Azure DevOps workflows with merge proposals and
+  <Card title="Enterprise GitOps Integration" icon="link">
+    Native GitHub, GitLab, BitBucket, Azure DevOps, and Gitea workflows with merge proposals and
     GPG signed commits for maximum security and auditability.
   </Card>
 
@@ -38,15 +38,11 @@ mode: "wide"
 
 ## Pro Features
 
-### Enterprise DevOps Integration
+### Enterprise GitOps Integration
 
 Flipt Pro provides native integration with popular source control management (SCM) platforms:
 
-- **GitHub Integration**: Create merge proposals directly from the Flipt UI that generate GitHub pull requests
-- **GitLab Support**: Seamless workflow integration with GitLab merge requests
-- **BitBucket Support**: Create pull requests and manage workflows with BitBucket repositories
-- **Azure DevOps**: Native support for Azure DevOps pull request workflows
-- **Gitea Support**: Self-hosted Git service integration with merge proposals
+- **Multi-Provider SCM Support**: Create merge proposals directly from the Flipt UI that generate pull requests across GitHub, GitLab, BitBucket, Azure DevOps, and Gitea
 - **GPG Commit Signing**: All commits are cryptographically signed for maximum security and auditability
 
 ### Integrated Secrets Management
@@ -128,7 +124,7 @@ For detailed configuration instructions, see our [licensing configuration docume
 
 <AccordionGroup>
   <Accordion title="What is the difference between Free and Pro editions?">
-    The Pro edition includes all Free edition features plus enterprise DevOps
+    The Pro edition includes all Free edition features plus enterprise GitOps
     integration, integrated secrets management, air-gapped environment support,
     and dedicated support. A license key is required to access Pro features.
   </Accordion>

--- a/v2/pro.mdx
+++ b/v2/pro.mdx
@@ -6,7 +6,7 @@ mode: "wide"
 
 <CardGroup cols={2}>
   <Card title="Enterprise DevOps Integration" icon="link">
-    Native GitHub, GitLab, and Azure DevOps workflows with merge proposals and
+    Native GitHub, GitLab, BitBucket, and Azure DevOps workflows with merge proposals and
     GPG signed commits for maximum security and auditability.
   </Card>
 
@@ -44,7 +44,9 @@ Flipt Pro provides native integration with popular source control management (SC
 
 - **GitHub Integration**: Create merge proposals directly from the Flipt UI that generate GitHub pull requests
 - **GitLab Support**: Seamless workflow integration with GitLab merge requests
+- **BitBucket Support**: Create pull requests and manage workflows with BitBucket repositories
 - **Azure DevOps**: Native support for Azure DevOps pull request workflows
+- **Gitea Support**: Self-hosted Git service integration with merge proposals
 - **GPG Commit Signing**: All commits are cryptographically signed for maximum security and auditability
 
 ### Integrated Secrets Management


### PR DESCRIPTION
Updates git-scm.mdx to document BitBucket SCM support for v2 environments.

Adds tabbed interface separating GitHub and BitBucket instructions, includes BitBucket app password and access token configuration, and provides authentication formats comparison table.

Fixes #343

Generated with [Claude Code](https://claude.ai/code)