### PR TITLE
docs: update v2 documentation for v2.0.0 release

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ Changes are automatically deployed to production when pushed to the main branch.
 
 - **Content**: All documentation files are in MDX format
 - **Navigation**: Configured in `docs.json` with versioned navigation (v1 and v2)
-- **Versions**: Supports both v1 (current) and v2 (beta) documentation
+- **Versions**: Supports both v1 (current) and v2 (stable) documentation
 - **Images**: Organized by section in `images/` directories
 - **Snippets**: Reusable content snippets in `snippets/`
 

--- a/concepts.mdx
+++ b/concepts.mdx
@@ -3,10 +3,6 @@ title: Concepts
 description: This document describes the basic concepts of Flipt.
 ---
 
-import V2Dev from "/snippets/v2-dev.mdx";
-
-<V2Dev />
-
 More information on how to use Flipt is noted in the [Getting Started](/introduction) documentation.
 
 ## Namespaces

--- a/docs.json
+++ b/docs.json
@@ -566,7 +566,7 @@
     "dark": "/logo/dark-logo.svg"
   },
   "banner": {
-    "content": "⚠️ **Flipt Cloud is shutting down on August 29, 2025.** Learn more about this decision and next steps in our [blog post](https://blog.flipt.io/sunsetting-flipt-cloud).",
+    "content": "🎉 **Flipt v2.0.0 is now available!** Experience the next generation of feature management with [Pro features](https://docs.flipt.io/v2/pro) and enhanced GitOps workflow.",
     "dismissible": true
   },
   "api": {

--- a/installation/overview.mdx
+++ b/installation/overview.mdx
@@ -3,10 +3,6 @@ title: "Overview"
 description: "Multiple ways to install and run Flipt on your own infrastructure"
 ---
 
-import V2Dev from "/snippets/v2-dev.mdx";
-
-<V2Dev />
-
 Flipt is a single binary that can be run on any Linux or macOS (arm64) host. You can install and try out Flipt in a few different ways:
 
 <CodeGroup>

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -3,10 +3,6 @@ title: Getting Started
 description: This document describes how to get started with Flipt.
 ---
 
-import V2Dev from "/snippets/v2-dev.mdx";
-
-<V2Dev />
-
 This document will walk you through creating your
 first flag, segment, set of rules, and finally using the evaluation console to
 simulate an evaluation request from your applications.
@@ -44,7 +40,7 @@ brew install flipt-io/brew/flipt
 
 </CodeGroup>
 
-In this example, we'll use the default location of http://localhost:8080.
+In this example, we'll use the default location of [http://localhost:8080](http://localhost:8080).
 
 ## Flags and Variants
 
@@ -57,7 +53,7 @@ applications that you want to enable/disable for your users.
 
 To create a flag:
 
-1. Open the UI at http://localhost:8080.
+1. Open the UI at [http://localhost:8080](http://localhost:8080).
 2. Click `New Flag`.
 3. Populate the details of the flag as shown.
 4. Click `Enabled` so the flag will be enabled once created.

--- a/snippets/v2-beta.mdx
+++ b/snippets/v2-beta.mdx
@@ -1,6 +1,6 @@
 <Info>
-  Flipt v2 is currently in **Beta** so there may still be some rough edges.
+  Flipt v2.0.0 is now **stable** and ready for production use!
 
-We are working hard to improve the docs. If you find any issues, please [open an issue](https://github.com/flipt-io/docs/issues/new?labels=v2).
+If you find any issues with the documentation, please [open an issue](https://github.com/flipt-io/docs/issues/new?labels=v2).
 
 </Info>

--- a/snippets/v2-dev.mdx
+++ b/snippets/v2-dev.mdx
@@ -1,4 +1,0 @@
-<Tip>
-  Flipt v2 is under active development! Check out our [v2 docs](/v2) to see
-  what's coming soon.
-</Tip>

--- a/usecases/overview.mdx
+++ b/usecases/overview.mdx
@@ -4,10 +4,6 @@ description: This document describes some of the general use cases for Flipt and
 mode: wide
 ---
 
-import V2Dev from "/snippets/v2-dev.mdx";
-
-<V2Dev />
-
 For more specific use cases that Flipt is suited for, see the following sections:
 
 - [CloudNative](/usecases/cloudnative/)

--- a/v2/guides/operations/authentication/login-with-github.mdx
+++ b/v2/guides/operations/authentication/login-with-github.mdx
@@ -79,7 +79,7 @@ The last bit of configuration is the session details. In order for the browser t
 docker run -it --rm \
   -p 8080:8080 \
   -v "$(pwd)/config.yml:/config.yml" \
-  flipt/flipt:v2-beta ./flipt server --config /config.yml
+  flipt/flipt:v2.0.0 ./flipt server --config /config.yml
 ```
 
 This will mount the `config.yml` as a volume in the container, and Flipt will use that configuration as it's provided as a command line flag option.

--- a/v2/guides/operations/authentication/login-with-github.mdx
+++ b/v2/guides/operations/authentication/login-with-github.mdx
@@ -79,7 +79,7 @@ The last bit of configuration is the session details. In order for the browser t
 docker run -it --rm \
   -p 8080:8080 \
   -v "$(pwd)/config.yml:/config.yml" \
-  flipt/flipt:v2.0.0 ./flipt server --config /config.yml
+  flipt/flipt:v2 ./flipt server --config /config.yml
 ```
 
 This will mount the `config.yml` as a volume in the container, and Flipt will use that configuration as it's provided as a command line flag option.

--- a/v2/guides/operations/deployment/deploy-to-kubernetes.mdx
+++ b/v2/guides/operations/deployment/deploy-to-kubernetes.mdx
@@ -113,19 +113,16 @@ You can adjust this file to include any configuration values you need based on t
 Once you have your `values.yaml` file (or to use default settings), install Flipt v2 with Helm:
 
 ```bash
-# Install with custom values (requires --devel flag while in beta)
-helm install flipt-v2 flipt/flipt-v2 -f values.yaml --devel
+# Install with custom values
+helm install flipt-v2 flipt/flipt-v2 -f values.yaml
 
 # Or install with default settings
-helm install flipt-v2 flipt/flipt-v2 --devel
+helm install flipt-v2 flipt/flipt-v2
 ```
 
 <Note>
   Note the chart name is `flipt-v2`, not `flipt`. This is the dedicated chart
   for Flipt v2 which includes v2-specific configurations and defaults.
-
-The `--devel` flag is required while Flipt v2 is in beta. This flag will no longer
-be needed once we release a stable version.
 
 </Note>
 

--- a/v2/installation.mdx
+++ b/v2/installation.mdx
@@ -15,7 +15,7 @@ docker run -d \
     -p 8080:8080 \
     -p 9000:9000 \
     -v $HOME/flipt:/var/opt/flipt \
-    docker.flipt.io/flipt/flipt:v2.0.0
+    docker.flipt.io/flipt/flipt:v2
 ```
 
 ```console Binary
@@ -71,7 +71,7 @@ docker run -d \
     -p 8080:8080 \
     -p 9000:9000 \
     -v $HOME/flipt:/var/opt/flipt \
-    docker.flipt.io/flipt/flipt:v2.0.0
+    docker.flipt.io/flipt/flipt:v2
 ```
 
 This will download the image and start a Flipt container and publish ports
@@ -111,7 +111,7 @@ docker run -d \
     -p 9000:9000 \
     -v $HOME/flipt:/var/opt/flipt \
     -v $HOME/flipt/config.yaml:/etc/flipt/config.yaml \
-    docker.flipt.io/flipt/flipt:v2.0.0
+    docker.flipt.io/flipt/flipt:v2
 ```
 
 ## Binary

--- a/v2/installation.mdx
+++ b/v2/installation.mdx
@@ -4,7 +4,7 @@ description: "Multiple ways to install and run Flipt v2 on your own infrastructu
 mode: "wide"
 ---
 
-Flipt v2 is a single binary that can be run on any Linux or macOS (arm64) host.
+Flipt v2 is a single binary that can be run on any Linux or macOS host.
 
 You can install and try out Flipt v2 in a few different ways:
 

--- a/v2/installation.mdx
+++ b/v2/installation.mdx
@@ -15,7 +15,7 @@ docker run -d \
     -p 8080:8080 \
     -p 9000:9000 \
     -v $HOME/flipt:/var/opt/flipt \
-    docker.flipt.io/flipt/flipt:v2-beta
+    docker.flipt.io/flipt/flipt:v2.0.0
 ```
 
 ```console Binary
@@ -24,7 +24,7 @@ curl -fsSL https://get.flipt.io/v2 | sh
 
 ```console Kubernetes/Helm
 helm repo add flipt https://helm.flipt.io
-helm install my-flipt-v2 flipt/flipt-v2 --devel
+helm install my-flipt-v2 flipt/flipt-v2
 ```
 
 </CodeGroup>
@@ -36,9 +36,8 @@ For more details on each installation method, see the sections below.
 - [Kubernetes/Helm](#kubernetes%2Fhelm)
 
 <Info>
-  Flipt v2 is currently in beta. Helm installation is now available for
-  Kubernetes deployments. Once we release a stable version, we'll add Homebrew
-  installation options.
+  Flipt v2.0.0 is now stable! Helm installation is available for Kubernetes
+  deployments. Homebrew installation options are coming soon.
 </Info>
 
 ## Supported Architectures
@@ -72,7 +71,7 @@ docker run -d \
     -p 8080:8080 \
     -p 9000:9000 \
     -v $HOME/flipt:/var/opt/flipt \
-    docker.flipt.io/flipt/flipt:v2-beta
+    docker.flipt.io/flipt/flipt:v2.0.0
 ```
 
 This will download the image and start a Flipt container and publish ports
@@ -112,7 +111,7 @@ docker run -d \
     -p 9000:9000 \
     -v $HOME/flipt:/var/opt/flipt \
     -v $HOME/flipt/config.yaml:/etc/flipt/config.yaml \
-    docker.flipt.io/flipt/flipt:v2-beta
+    docker.flipt.io/flipt/flipt:v2.0.0
 ```
 
 ## Binary
@@ -167,21 +166,17 @@ Add the Flipt Helm repository and install Flipt v2:
 helm repo add flipt https://helm.flipt.io
 helm repo update
 
-# Install Flipt v2 (requires --devel flag while in beta)
-helm install my-flipt-v2 flipt/flipt-v2 --devel
+# Install Flipt v2
+helm install my-flipt-v2 flipt/flipt-v2
 
 # Or with custom configuration
-helm install my-flipt-v2 flipt/flipt-v2 -f values.yaml --devel
+helm install my-flipt-v2 flipt/flipt-v2 -f values.yaml
 ```
 
 <Note>
 
 The chart name is `flipt-v2`, which is separate from the v1 `flipt` chart.
 This ensures v2-specific configurations and compatibility.
-
-The `--devel` flag
-is required while Flipt v2 is in beta. This flag will no longer be needed once
-we release a stable version.
 
 </Note>
 

--- a/v2/quickstart.mdx
+++ b/v2/quickstart.mdx
@@ -24,7 +24,7 @@ docker run -d \
     -p 8080:8080 \
     -p 9000:9000 \
     -v $HOME/flipt:/var/opt/flipt \
-    docker.flipt.io/flipt/flipt:v2.0.0
+    docker.flipt.io/flipt/flipt:v2
 ```
 
 </CodeGroup>

--- a/v2/quickstart.mdx
+++ b/v2/quickstart.mdx
@@ -24,7 +24,7 @@ docker run -d \
     -p 8080:8080 \
     -p 9000:9000 \
     -v $HOME/flipt:/var/opt/flipt \
-    docker.flipt.io/flipt/flipt:v2-beta
+    docker.flipt.io/flipt/flipt:v2.0.0
 ```
 
 </CodeGroup>


### PR DESCRIPTION
This PR updates all v2 documentation to remove beta references and announce the v2.0.0 release.

## Changes
- Updated banner to announce v2.0.0 availability with Pro features link
- Removed all beta references from v2 documentation
- Updated docker tags from v2-beta to v2.0.0
- Removed Helm --devel flag requirements for stable release
- Updated snippets and CLAUDE.md to reflect stable status

Resolves #345

Generated with [Claude Code](https://claude.ai/code)