### PR TITLE
docs: Flipt v2 Dockerfile installation command something wrong

### DIFF
--- a/installation/docker.mdx
+++ b/installation/docker.mdx
@@ -61,6 +61,6 @@ docker run -d \
     -p 8080:8080 \
     -p 9000:9000 \
     -v $HOME/flipt:/var/opt/flipt \
-    -v $HOME/flipt/config.yaml:/etc/flipt/config.yaml \
+    -v $HOME/flipt/config.yaml:/etc/flipt/config/default.yml \
     docker.flipt.io/flipt/flipt:latest
 ```


### PR DESCRIPTION
Hello,

I'm having trouble getting the Flipt v2 container to load my custom config.yml file. I'm using a volume mount in Docker, but the server seems to be ignoring my configuration and starting with the defaults. I suspect there might be an issue with the file path.

I've set the destination path to /etc/flipt/config/default.yml, which I believe is correct based on the documentation.

Could you please review my configuration below and let me know if you see any mistakes?

(translate by gemini. I can't speak english very well sorry 🙏)