### PR TITLE
docs: add homebrew installation instructions for v2

### DIFF
--- a/v2/installation.mdx
+++ b/v2/installation.mdx
@@ -40,11 +40,6 @@ For more details on each installation method, see the sections below.
 - [Kubernetes/Helm](#kubernetes%2Fhelm)
 - [Homebrew](#homebrew)
 
-<Info>
-  Flipt v2.0.0 is now stable! Helm and Homebrew installation options are
-  available.
-</Info>
-
 ## Supported Architectures
 
 Flipt v2 is built for the following architectures/os:

--- a/v2/installation.mdx
+++ b/v2/installation.mdx
@@ -27,6 +27,10 @@ helm repo add flipt https://helm.flipt.io
 helm install my-flipt-v2 flipt/flipt-v2
 ```
 
+```console Homebrew
+brew install flipt-io/brew/flipt@2
+```
+
 </CodeGroup>
 
 For more details on each installation method, see the sections below.
@@ -34,10 +38,11 @@ For more details on each installation method, see the sections below.
 - [Docker](#docker)
 - [Binary](#binary)
 - [Kubernetes/Helm](#kubernetes%2Fhelm)
+- [Homebrew](#homebrew)
 
 <Info>
-  Flipt v2.0.0 is now stable! Helm installation is available for Kubernetes
-  deployments. Homebrew installation options are coming soon.
+  Flipt v2.0.0 is now stable! Helm and Homebrew installation options are
+  available.
 </Info>
 
 ## Supported Architectures
@@ -112,6 +117,29 @@ docker run -d \
     -v $HOME/flipt:/var/opt/flipt \
     -v $HOME/flipt/config.yaml:/etc/flipt/config.yaml \
     docker.flipt.io/flipt/flipt:v2
+```
+
+## Homebrew
+
+You can install Flipt v2 using [Homebrew](https://brew.sh/) on macOS and Linux.
+
+<Note>
+  If you have Flipt v1 installed via Homebrew, you'll need to unlink it first:
+  `brew unlink flipt`
+</Note>
+
+### Installing
+
+```console
+brew install flipt-io/brew/flipt@2
+```
+
+### Running
+
+Once installed, you can run Flipt v2 with:
+
+```console
+flipt server [--config OPTIONAL_PATH_TO_YOUR_CONFIG]
 ```
 
 ## Binary


### PR DESCRIPTION
Add homebrew installation instructions for Flipt v2 including:

- New homebrew option in main code group
- Dedicated homebrew section with installation and running instructions
- Note about unlinking v1 for existing users
- Updated info section to mention homebrew availability
- Added homebrew to table of contents

Closes #354
Closes https://github.com/flipt-io/homebrew-brew/issues/5

Generated with [Claude Code](https://claude.ai/code)