### PR TITLE
chore: fix Bitbucket spelling in v2 docs

### DIFF
--- a/v2/guides/operations/deployment/deploy-to-kubernetes.mdx
+++ b/v2/guides/operations/deployment/deploy-to-kubernetes.mdx
@@ -171,7 +171,7 @@ Flipt v2's Git-native storage works seamlessly in Kubernetes environments. The d
 
 - **Clone repositories**: Automatically clone and sync with your Git repository containing feature flag definitions
 - **Work offline**: Continue serving flags even when the source Git repository is temporarily unavailable
-- **Support multiple Git providers**: Works with GitHub, GitLab, BitBucket, Azure DevOps, Gitea, and other Git platforms
+- **Support multiple Git providers**: Works with GitHub, GitLab, Bitbucket, Azure DevOps, Gitea, and other Git platforms
 
 ### Environment Support
 

--- a/v2/guides/operations/environments/git-scm.mdx
+++ b/v2/guides/operations/environments/git-scm.mdx
@@ -17,7 +17,7 @@ import V2Pro from "/snippets/v2-pro.mdx";
 
 <Note>
   Flipt v2 SCM integration supports most of the major Git providers including
-  GitHub, GitLab, BitBucket, Gitea, and Azure DevOps.
+  GitHub, GitLab, Bitbucket, Gitea, and Azure DevOps.
 </Note>
 
 ## 1. Configure SCM Integration
@@ -88,9 +88,9 @@ environments:
 ```
 
 </Tab>
-<Tab title="BitBucket">
+<Tab title="Bitbucket">
 
-## BitBucket Integration
+## Bitbucket Integration
 
 ### 1. Create API Token or App Password
 
@@ -99,9 +99,9 @@ environments:
   strongly recommend using API tokens instead.
 </Warning>
 
-**Option A: API Token (Recommended for BitBucket Cloud)**
+**Option A: API Token (Recommended for Bitbucket Cloud)**
 
-1. Go to [BitBucket Account Settings > API tokens](https://bitbucket.org/account/settings/api-tokens/)
+1. Go to [Bitbucket Account Settings > API tokens](https://bitbucket.org/account/settings/api-tokens/)
 2. Click **"Create API token"**
 3. Give your token a name
 4. Select the following scopes (**required**):
@@ -116,7 +116,7 @@ environments:
   be deprecated on September 9, 2025 and will stop working on June 9, 2026.**
 </Note>
 
-1. Go to [BitBucket Account Settings > App passwords](https://bitbucket.org/account/settings/app-passwords/)
+1. Go to [Bitbucket Account Settings > App passwords](https://bitbucket.org/account/settings/app-passwords/)
 2. Click **"Create app password"**
 3. Give your app password a name
 4. Select the following permissions (**required**):
@@ -124,15 +124,15 @@ environments:
    - Pull requests: Read, Write
 5. Click **"Create"** and copy the generated password. **You will not be able to see it again!**
 
-**Option C: Access Token (For BitBucket Server/Data Center)**
+**Option C: Access Token (For Bitbucket Server/Data Center)**
 
-1. Go to your BitBucket Server settings
+1. Go to your Bitbucket Server settings
 2. Navigate to Personal access tokens
 3. Create a new token with repository and pull request permissions
 
-### 2. Configure BitBucket Credentials
+### 2. Configure Bitbucket Credentials
 
-Edit your Flipt configuration file to use the BitBucket credentials:
+Edit your Flipt configuration file to use the Bitbucket credentials:
 
 **Using API Token (Recommended):**
 
@@ -154,7 +154,7 @@ credentials:
       password: <your-app-password>
 ```
 
-**Using Access Token (BitBucket Server/Data Center):**
+**Using Access Token (Bitbucket Server/Data Center):**
 
 ```yaml
 credentials:
@@ -163,9 +163,9 @@ credentials:
     access_token: <your-access-token>
 ```
 
-### 3. Configure Flipt Storage with BitBucket Remote
+### 3. Configure Flipt Storage with Bitbucket Remote
 
-Edit your Flipt configuration file to add or update the storage backend that syncs with your BitBucket repository:
+Edit your Flipt configuration file to add or update the storage backend that syncs with your Bitbucket repository:
 
 ```yaml
 storage:
@@ -179,9 +179,9 @@ storage:
       path: "/path/to/local/clone"
 ```
 
-### 4. Configure an Environment to use BitBucket SCM
+### 4. Configure an Environment to use Bitbucket SCM
 
-Edit your Flipt configuration file to add or update the environment that uses the BitBucket SCM storage backend and add the `scm` section:
+Edit your Flipt configuration file to add or update the environment that uses the Bitbucket SCM storage backend and add the `scm` section:
 
 ```yaml highlight={6-8}
 environments:
@@ -194,7 +194,7 @@ environments:
       credentials: "bitbucket"
 ```
 
-**For BitBucket Server (Custom Instance):**
+**For Bitbucket Server (Custom Instance):**
 
 ```yaml highlight={6-9}
 environments:
@@ -386,11 +386,11 @@ Start or restart your Flipt server with the updated configuration. Flipt will no
 - Ensure your PAT has the correct repository scopes (`contents` and `pull-requests`)
 - Verify the repository URL format: `https://github.com/{owner}/{repo}.git`
 
-**BitBucket:**
+**Bitbucket:**
 
 - For API tokens: Ensure you have `Repositories: Read, Write` and `Pull requests: Read, Write` scopes
 - For app passwords: Note that they will be deprecated in September 2025
-- For BitBucket Server/Data Center: Verify the API URL format (typically `/api/v2.0`)
+- For Bitbucket Server/Data Center: Verify the API URL format (typically `/api/v2.0`)
 
 **Azure DevOps:**
 
@@ -412,7 +412,7 @@ Different Git providers require different authentication formats for optimal com
 | ---------------- | ----------------------- | -------------------------------------- | ---------------------------------- |
 | **GitHub**       | Personal Access Token   | Username: token, Password: (empty)     |                                    |
 | **GitLab**       | Personal Access Token   | Username: oauth2, Password: token      |                                    |
-| **BitBucket**    | API Token               | Username: (not used), Token: api_token | App passwords deprecated Sept 2025 |
+| **Bitbucket**    | API Token               | Username: (not used), Token: api_token | App passwords deprecated Sept 2025 |
 | **Azure DevOps** | Personal Access Token   | Username: username, Password: PAT      |                                    |
 | **Gitea**        | Personal Access Token   | Username: token, Password: (empty)     |                                    |
 

--- a/v2/guides/user/environments/merge-proposals.mdx
+++ b/v2/guides/user/environments/merge-proposals.mdx
@@ -18,7 +18,7 @@ import V2Pro from "/snippets/v2-pro.mdx";
 
 <Note>
   Flipt v2 merge proposals are supported by most of the major Git providers
-  including GitHub, GitLab, BitBucket, Gitea, and Azure DevOps.
+  including GitHub, GitLab, Bitbucket, Gitea, and Azure DevOps.
 </Note>
 
 ## Using Merge Proposals

--- a/v2/introduction.mdx
+++ b/v2/introduction.mdx
@@ -21,7 +21,7 @@ Flipt v2 introduces a number of new features and capabilities that are not avail
 
 Flipt v2 is built to be Git-native, meaning that your feature flags and configurations are stored in your own Git repositories. This allows you to use your existing Git workflow and tools to manage your feature flags and configurations.
 
-By default, Flipt v2 uses a local git-backed storage backend that is stored in memory or on disk. You can also configure Flipt v2 to sync your local git-backed storage to a remote Git repository such as **GitHub, GitLab, BitBucket, Azure DevOps, and Gitea**.
+By default, Flipt v2 uses a local git-backed storage backend that is stored in memory or on disk. You can also configure Flipt v2 to sync your local git-backed storage to a remote Git repository such as **GitHub, GitLab, Bitbucket, Azure DevOps, and Gitea**.
 
 We modeled Flipt v2 after our Flipt Cloud product, but with the ability to self-host.
 
@@ -58,7 +58,7 @@ Branches use Git under the hood and create a complete copy of the base environme
 
 ### Merge Proposals
 
-Flipt v2 allows you to create merge proposals for any environment branch. This enables you to review changes from your branched environments before merging them into the base environment. This models the same workflow as GitHub Pull Requests, GitLab Merge Requests, and BitBucket Pull Requests.
+Flipt v2 allows you to create merge proposals for any environment branch. This enables you to review changes from your branched environments before merging them into the base environment. This models the same workflow as GitHub Pull Requests, GitLab Merge Requests, and Bitbucket Pull Requests.
 
 ![Flipt v2 Merge Proposals](/v2/images/introduction/merge_proposals.png)
 
@@ -74,7 +74,7 @@ Flipt v2 introduces a new streaming API that allows you to subscribe to changes 
 
 Flipt v2 is a standalone binary that does not depend on any external services. This means that you can run Flipt v2 on any machine that has a compatible operating system.
 
-V2 does not require any database or cache by default. Even the git-backed storage is local by default either in memory or on disk. You can configure Flipt v2 to sync your local git-backed storage to a remote Git repository such as GitHub, GitLab, BitBucket, Azure DevOps, or Gitea.
+V2 does not require any database or cache by default. Even the git-backed storage is local by default either in memory or on disk. You can configure Flipt v2 to sync your local git-backed storage to a remote Git repository such as GitHub, GitLab, Bitbucket, Azure DevOps, or Gitea.
 
 ### Secrets Management
 

--- a/v2/licensing.mdx
+++ b/v2/licensing.mdx
@@ -29,7 +29,7 @@ The **majority of Flipt v2 remains free and open source**, including:
 | Authentication mechanisms           | ✅   | ✅  | OIDC, token-based                                                                                                                 |
 | Real-time client updates            | ✅   | ✅  | Server Sent Events (SSE) support                                                                                                  |
 | **Advanced Workflows**              |      |     |                                                                                                                                   |
-| Enterprise DevOps Integration       | ❌   | ✅  | GitHub, GitLab, BitBucket, Azure DevOps, Gitea                                                                                    |
+| Enterprise DevOps Integration       | ❌   | ✅  | GitHub, GitLab, Bitbucket, Azure DevOps, Gitea                                                                                    |
 | Merge proposals with SCM            | ❌   | ✅  | Automated PR/MR creation                                                                                                          |
 | GPG commit signing                  | ❌   | ✅  | Cryptographic verification                                                                                                        |
 | **Security & Operations**           |      |     |                                                                                                                                   |

--- a/v2/pro.mdx
+++ b/v2/pro.mdx
@@ -6,7 +6,7 @@ mode: "wide"
 
 <CardGroup cols={2}>
   <Card title="Enterprise GitOps Integration" icon="link">
-    Native GitHub, GitLab, BitBucket, Azure DevOps, and Gitea workflows with merge proposals and
+    Native GitHub, GitLab, Bitbucket, Azure DevOps, and Gitea workflows with merge proposals and
     GPG signed commits for maximum security and auditability.
   </Card>
 
@@ -43,7 +43,7 @@ mode: "wide"
 
 Flipt Pro provides native integration with popular source control management (SCM) platforms:
 
-- **Multi-Provider SCM Support**: Create merge proposals directly from the Flipt UI that generate pull requests across GitHub, GitLab, BitBucket, Azure DevOps, and Gitea
+- **Multi-Provider SCM Support**: Create merge proposals directly from the Flipt UI that generate pull requests across GitHub, GitLab, Bitbucket, Azure DevOps, and Gitea
 - **GPG Commit Signing**: All commits are cryptographically signed for maximum security and auditability
 
 ### Integrated Secrets Management


### PR DESCRIPTION
Corrected all instances of "BitBucket" to proper spelling "Bitbucket" across v2 documentation files.

Closes #356

Generated with [Claude Code](https://claude.ai/code)