### PR TITLE
docs: add Git repository initialization guide for v2

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -29,7 +29,10 @@
                 "groups": [
                   {
                     "group": "Overview",
-                    "pages": ["introduction", "concepts"]
+                    "pages": [
+                      "introduction",
+                      "concepts"
+                    ]
                   },
                   {
                     "group": "Use Cases",
@@ -174,7 +177,9 @@
                   },
                   {
                     "group": "Authorization",
-                    "pages": ["authorization/overview"]
+                    "pages": [
+                      "authorization/overview"
+                    ]
                   },
                   {
                     "group": "Operations",
@@ -201,7 +206,9 @@
                 "groups": [
                   {
                     "group": "Overview",
-                    "pages": ["reference/overview"]
+                    "pages": [
+                      "reference/overview"
+                    ]
                   },
                   {
                     "group": "Authentication",
@@ -312,12 +319,9 @@
               {
                 "anchor": "Changelog",
                 "icon": "clock",
-                "pages": ["changelog/overview"]
-              },
-              {
-                "anchor": "AI Context",
-                "href": "https://docs.flipt.io/llms.txt",
-                "icon": "robot"
+                "pages": [
+                  "changelog/overview"
+                ]
               },
               {
                 "anchor": "Blog",
@@ -361,7 +365,10 @@
                     "group": "Pro Features",
                     "tag": "NEW",
                     "icon": "crown",
-                    "pages": ["/v2/pro", "/v2/licensing"]
+                    "pages": [
+                      "/v2/pro",
+                      "/v2/licensing"
+                    ]
                   },
                   {
                     "group": "Configuration",
@@ -387,7 +394,9 @@
                       "v2/integration/overview",
                       {
                         "group": "Server-Side SDKs",
-                        "pages": ["v2/integration/server/rest"]
+                        "pages": [
+                          "v2/integration/server/rest"
+                        ]
                       },
                       "v2/integration/client",
                       "v2/integration/openfeature"
@@ -462,7 +471,9 @@
                       },
                       {
                         "group": "Migration Guides",
-                        "pages": ["v2/guides/migration/cloud/flipt-cloud-to-v2"]
+                        "pages": [
+                          "v2/guides/migration/cloud/flipt-cloud-to-v2"
+                        ]
                       }
                     ]
                   },
@@ -470,14 +481,11 @@
                     "group": "Tooling",
                     "icon": "hammer",
                     "tag": "NEW",
-                    "pages": ["v2/tooling/github-actions"]
+                    "pages": [
+                      "v2/tooling/github-actions"
+                    ]
                   }
                 ]
-              },
-              {
-                "anchor": "AI Context",
-                "href": "https://docs.flipt.io/llms.txt",
-                "icon": "robot"
               },
               {
                 "anchor": "Blog",

--- a/docs.json
+++ b/docs.json
@@ -29,10 +29,7 @@
                 "groups": [
                   {
                     "group": "Overview",
-                    "pages": [
-                      "introduction",
-                      "concepts"
-                    ]
+                    "pages": ["introduction", "concepts"]
                   },
                   {
                     "group": "Use Cases",
@@ -177,9 +174,7 @@
                   },
                   {
                     "group": "Authorization",
-                    "pages": [
-                      "authorization/overview"
-                    ]
+                    "pages": ["authorization/overview"]
                   },
                   {
                     "group": "Operations",
@@ -206,9 +201,7 @@
                 "groups": [
                   {
                     "group": "Overview",
-                    "pages": [
-                      "reference/overview"
-                    ]
+                    "pages": ["reference/overview"]
                   },
                   {
                     "group": "Authentication",
@@ -319,9 +312,7 @@
               {
                 "anchor": "Changelog",
                 "icon": "clock",
-                "pages": [
-                  "changelog/overview"
-                ]
+                "pages": ["changelog/overview"]
               },
               {
                 "anchor": "AI Context",
@@ -370,10 +361,7 @@
                     "group": "Pro Features",
                     "tag": "NEW",
                     "icon": "crown",
-                    "pages": [
-                      "/v2/pro",
-                      "/v2/licensing"
-                    ]
+                    "pages": ["/v2/pro", "/v2/licensing"]
                   },
                   {
                     "group": "Configuration",
@@ -399,9 +387,7 @@
                       "v2/integration/overview",
                       {
                         "group": "Server-Side SDKs",
-                        "pages": [
-                          "v2/integration/server/rest"
-                        ]
+                        "pages": ["v2/integration/server/rest"]
                       },
                       "v2/integration/client",
                       "v2/integration/openfeature"
@@ -466,6 +452,7 @@
                           {
                             "group": "Environments",
                             "pages": [
+                              "v2/guides/operations/environments/git-repository-initialization",
                               "v2/guides/operations/environments/git-sync",
                               "v2/guides/operations/environments/git-scm",
                               "v2/guides/operations/environments/commit-signing-setup"
@@ -475,9 +462,7 @@
                       },
                       {
                         "group": "Migration Guides",
-                        "pages": [
-                          "v2/guides/migration/cloud/flipt-cloud-to-v2"
-                        ]
+                        "pages": ["v2/guides/migration/cloud/flipt-cloud-to-v2"]
                       }
                     ]
                   },
@@ -485,9 +470,7 @@
                     "group": "Tooling",
                     "icon": "hammer",
                     "tag": "NEW",
-                    "pages": [
-                      "v2/tooling/github-actions"
-                    ]
+                    "pages": ["v2/tooling/github-actions"]
                   }
                 ]
               },

--- a/v2/configuration/storage.mdx
+++ b/v2/configuration/storage.mdx
@@ -53,6 +53,8 @@ storage:
 
 The above configuration will create a local storage backend with the identifier `default` and serve Flipt flag state from the current working directory.
 
+For guidance on setting up Git repositories with existing feature files, see our [Git Repository Initialization guide](/v2/guides/operations/environments/git-repository-initialization).
+
 ### Memory
 
 The purpose of this backend type is to support serving Flipt flag state from an in-memory store.

--- a/v2/guides/operations/environments/git-repository-initialization.mdx
+++ b/v2/guides/operations/environments/git-repository-initialization.mdx
@@ -9,13 +9,6 @@ This guide explains how to set up Git repository initialization for existing fea
 
 Flipt v2 supports automatic Git repository detection and initialization for existing feature files when using the local storage backend. This addresses the common workflow where you have existing feature flag configurations but no Git repository initialized yet.
 
-Previously, when users had existing feature files but no Git repository, Flipt would fail with errors like:
-
-- `"repository does not exist"`
-- `"reference not found"`
-
-With the enhancements introduced in Flipt v2, you can now follow an intuitive workflow to initialize Git repositories for your existing feature configurations.
-
 ## Supported File Formats
 
 Flipt v2 supports both YAML file extensions for feature configurations:

--- a/v2/guides/operations/environments/git-repository-initialization.mdx
+++ b/v2/guides/operations/environments/git-repository-initialization.mdx
@@ -9,6 +9,15 @@ This guide explains how to set up Git repository initialization for existing fea
 
 Flipt v2 supports automatic Git repository detection and initialization for existing feature files when using the local storage backend. This addresses the common workflow where you have existing feature flag configurations but no Git repository initialized yet.
 
+<Note>
+  This is only necessary if you want to pre-populate Flipt with existing feature
+  data from your local machine.
+
+If you are starting fresh or have data synced to
+a remote repository then following this guide is not necessary.
+
+</Note>
+
 ## Supported File Formats
 
 Flipt v2 supports both YAML file extensions for feature configurations:
@@ -140,7 +149,6 @@ You can also combine local storage with remote Git synchronization:
 ```yaml
 storage:
   local:
-    name: "Local with Remote"
     remote: "https://github.com/your-org/feature-flags.git"
     branch: "main"
     poll_interval: "30s"
@@ -205,22 +213,7 @@ Check that:
 1. Your feature files use the correct naming: `features.yaml` or `features.yml`
 2. The files are in the correct directory structure
 3. The YAML syntax is valid
-
-### Changes Not Persisting
-
-For normal Git repositories:
-
-- Changes made in the UI should automatically sync to your files
-- Check that Flipt has write permissions to the directory
-- Verify that the Git repository is properly initialized
-
-## Best Practices
-
-1. **Use Descriptive Commit Messages**: When initializing your repository, use clear commit messages that describe your feature set
-2. **Organize by Environment**: Structure your directories to separate different environments (staging, production, etc.)
-3. **Regular Commits**: Consider setting up automated commits for changes made through the UI
-4. **Backup Strategy**: Implement a backup strategy for your feature flag configurations
-5. **File Naming**: Stick to either `.yaml` or `.yml` consistently across your project
+4. You added and committed the files at `path`
 
 ## Backward Compatibility
 

--- a/v2/guides/operations/environments/git-repository-initialization.mdx
+++ b/v2/guides/operations/environments/git-repository-initialization.mdx
@@ -46,7 +46,7 @@ Navigate to your flags directory and initialize Git:
 
 ```bash
 cd my-project/flags
-git init
+git init -b main
 git add .
 git commit -m "Initial features"
 ```

--- a/v2/guides/operations/environments/git-repository-initialization.mdx
+++ b/v2/guides/operations/environments/git-repository-initialization.mdx
@@ -1,0 +1,240 @@
+---
+title: Git Repository Initialization
+description: Learn how to initialize Git repositories for existing feature flag configurations in Flipt v2.
+---
+
+This guide explains how to set up Git repository initialization for existing feature flag configurations in Flipt v2. This is particularly useful when you already have `features.yaml` or `features.yml` files but need to initialize version control for them.
+
+## Overview
+
+Flipt v2 supports automatic Git repository detection and initialization for existing feature files when using the local storage backend. This addresses the common workflow where you have existing feature flag configurations but no Git repository initialized yet.
+
+Previously, when users had existing feature files but no Git repository, Flipt would fail with errors like:
+
+- `"repository does not exist"`
+- `"reference not found"`
+
+With the enhancements introduced in Flipt v2, you can now follow an intuitive workflow to initialize Git repositories for your existing feature configurations.
+
+## Supported File Formats
+
+Flipt v2 supports both YAML file extensions for feature configurations:
+
+- `features.yaml` (recommended)
+- `features.yml`
+
+Both formats work identically and you can use whichever extension you prefer.
+
+## Basic Setup Workflow
+
+The typical workflow for initializing a Git repository with existing feature files is:
+
+### 1. Organize Your Feature Files
+
+Create a directory structure with your existing features:
+
+```bash
+mkdir -p my-project/flags/production
+cp existing-features.yaml my-project/flags/production/features.yaml
+```
+
+### 2. Initialize Git Repository
+
+Navigate to your flags directory and initialize Git:
+
+```bash
+cd my-project/flags
+git init
+git add .
+git commit -m "Initial features"
+```
+
+### 3. Configure Flipt
+
+Create a Flipt configuration that points to your flags directory:
+
+```yaml
+storage:
+  local:
+    name: "local"
+    backend:
+      type: local
+      path: "flags" # Path to your flags directory
+    branch: "main"
+
+environments:
+  default:
+    name: "Default"
+    storage: "local"
+    default: true
+```
+
+### 4. Start Flipt Server
+
+Run Flipt pointing to your configuration:
+
+```bash
+cd ..  # Back to my-project directory
+flipt server --config config.yml
+```
+
+## Repository Detection
+
+Flipt v2 includes enhanced repository detection logic that can handle:
+
+1. **Normal Git Repositories**: Standard repositories created with `git init` (with `.git` subdirectory)
+2. **Bare Repositories**: Repositories managed internally by Flipt (Git files in root directory)
+3. **Automatic Fallback**: Graceful handling when repository types are ambiguous
+
+The system automatically:
+
+- Detects the repository type
+- Creates necessary remote tracking references (`refs/remotes/origin/main`)
+- Sets up proper branch management for Flipt's operations
+
+## Working Directory Synchronization
+
+When you make changes through the Flipt UI, the system automatically:
+
+- Updates the actual `.yaml` files on disk for normal repositories
+- Maintains backward compatibility with existing bare repository workflows
+- Synchronizes changes back to the filesystem
+
+This means changes made in the Flipt web interface will be reflected in your actual feature files, allowing you to see modifications through standard Git tools.
+
+## Configuration Examples
+
+### Basic Local Storage
+
+```yaml
+storage:
+  backend:
+    type: local
+    path: "." # Current directory
+```
+
+### Multiple Environments
+
+```yaml
+storage:
+  staging:
+    name: "Staging"
+    backend:
+      type: local
+      path: "flags/staging"
+    branch: "staging"
+  production:
+    name: "Production"
+    backend:
+      type: local
+      path: "flags/production"
+    branch: "main"
+
+environments:
+  staging:
+    name: "Staging"
+    storage: "staging"
+  production:
+    name: "Production"
+    storage: "production"
+    default: true
+```
+
+### With Remote Git Repository
+
+You can also combine local storage with remote Git synchronization:
+
+```yaml
+storage:
+  local:
+    name: "Local with Remote"
+    remote: "https://github.com/your-org/feature-flags.git"
+    branch: "main"
+    poll_interval: "30s"
+    credentials: "github"
+    backend:
+      type: local
+      path: "flags"
+
+environments:
+  default:
+    name: "Default"
+    storage: "local"
+    default: true
+
+credentials:
+  github:
+    type: access_token
+    access_token: "your-github-token"
+```
+
+## Docker Usage
+
+When using Docker, you can initialize the repository in your container build process:
+
+```dockerfile
+FROM docker-registry.example.com/base:latest as builder
+
+COPY main/features /tmp/data
+RUN cd /tmp/data && \
+    git config --global init.defaultBranch main && \
+    git init && \
+    git config user.name "Flipt Container" && \
+    git config user.email "flipt@container.local" && \
+    git add . && \
+    git commit -m "Initial commit with feature flags"
+
+FROM docker.flipt.io/flipt/flipt:v2
+
+COPY --from=builder --chown=flipt:flipt /tmp/data /data
+COPY --chown=flipt:flipt main/config.yml /config.yml
+
+USER flipt
+EXPOSE 8080 9000
+
+CMD ["/flipt", "server", "--config", "/config.yml"]
+```
+
+## Troubleshooting
+
+### Repository Does Not Exist Error
+
+If you see this error, ensure that:
+
+1. Your `path` configuration points to a valid directory
+2. The directory contains your feature files
+3. Git is properly initialized in the directory
+
+### Features Not Loading
+
+Check that:
+
+1. Your feature files use the correct naming: `features.yaml` or `features.yml`
+2. The files are in the correct directory structure
+3. The YAML syntax is valid
+
+### Changes Not Persisting
+
+For normal Git repositories:
+
+- Changes made in the UI should automatically sync to your files
+- Check that Flipt has write permissions to the directory
+- Verify that the Git repository is properly initialized
+
+## Best Practices
+
+1. **Use Descriptive Commit Messages**: When initializing your repository, use clear commit messages that describe your feature set
+2. **Organize by Environment**: Structure your directories to separate different environments (staging, production, etc.)
+3. **Regular Commits**: Consider setting up automated commits for changes made through the UI
+4. **Backup Strategy**: Implement a backup strategy for your feature flag configurations
+5. **File Naming**: Stick to either `.yaml` or `.yml` consistently across your project
+
+## Backward Compatibility
+
+This enhancement is fully backward compatible:
+
+- Existing bare repository workflows continue to work unchanged
+- All existing functionality is preserved
+- Safe fallbacks handle edge cases gracefully
+
+You can migrate existing setups without any breaking changes.


### PR DESCRIPTION
Add comprehensive documentation for initializing Git repositories with existing features files in Flipt v2. This addresses the common workflow where users have existing feature.yaml/yml files but no Git repository initialized.

Key features documented:
- Support for both features.yaml and features.yml
- Git repository detection and initialization
- Working directory synchronization
- Docker usage patterns
- Configuration examples and troubleshooting

Closes #361 (documents .yml file support)
Related to flipt-io/flipt#4674 and flipt-io/flipt#4623

Generated with [Claude Code](https://claude.ai/code)