### PR TITLE
docs: fix Docker config paths for v2 documentation

### DIFF
--- a/docs/.vale/styles/Microsoft/HeadingAcronyms.yml
+++ b/docs/.vale/styles/Microsoft/HeadingAcronyms.yml
@@ -4,4 +4,4 @@ link: https://docs.microsoft.com/en-us/style-guide/acronyms#be-careful-with-acro
 level: warning
 scope: heading
 tokens:
-  - '[A-Z]{2,4}'
+  - "[A-Z]{2,4}"

--- a/docs/.vale/styles/Microsoft/Headings.yml
+++ b/docs/.vale/styles/Microsoft/Headings.yml
@@ -5,7 +5,7 @@ level: suggestion
 scope: heading
 match: $sentence
 indicators:
-  - ':'
+  - ":"
 exceptions:
   - Azure
   - CLI

--- a/docs/.vale/styles/Microsoft/Quotes.yml
+++ b/docs/.vale/styles/Microsoft/Quotes.yml
@@ -1,5 +1,5 @@
 extends: existence
-message: 'Punctuation should be inside the quotes.'
+message: "Punctuation should be inside the quotes."
 link: https://docs.microsoft.com/en-us/style-guide/punctuation/quotation-marks
 level: error
 nonword: true

--- a/docs/.vale/styles/Microsoft/Semicolon.yml
+++ b/docs/.vale/styles/Microsoft/Semicolon.yml
@@ -5,4 +5,4 @@ nonword: true
 scope: sentence
 level: suggestion
 tokens:
-  - ';'
+  - ";"

--- a/docs/.vale/styles/Microsoft/SentenceLength.yml
+++ b/docs/.vale/styles/Microsoft/SentenceLength.yml
@@ -4,4 +4,3 @@ scope: sentence
 level: suggestion
 max: 30
 token: \b(\w+)\b
-

--- a/docs/.vale/styles/Microsoft/Spacing.yml
+++ b/docs/.vale/styles/Microsoft/Spacing.yml
@@ -4,5 +4,5 @@ link: https://docs.microsoft.com/en-us/style-guide/punctuation/periods
 level: error
 nonword: true
 tokens:
-  - '[a-z][.?!] {2,}[A-Z]'
-  - '[a-z][.?!][A-Z]'
+  - "[a-z][.?!] {2,}[A-Z]"
+  - "[a-z][.?!][A-Z]"

--- a/docs/.vale/styles/Microsoft/Units.yml
+++ b/docs/.vale/styles/Microsoft/Units.yml
@@ -5,10 +5,10 @@ level: error
 raw:
   - '[a-zA-Z]+\s'
 tokens:
-  - '(?:centi|milli)?meters'
-  - '(?:kilo)?grams'
-  - '(?:kilo)?meters'
-  - '(?:mega)?pixels'
+  - "(?:centi|milli)?meters"
+  - "(?:kilo)?grams"
+  - "(?:kilo)?meters"
+  - "(?:mega)?pixels"
   - cm
   - inches
   - lb

--- a/docs/.vale/styles/Microsoft/Vocab.yml
+++ b/docs/.vale/styles/Microsoft/Vocab.yml
@@ -1,6 +1,6 @@
 extends: existence
 message: "Verify your use of '%s' with the A-Z word list."
-link: 'https://docs.microsoft.com/en-us/style-guide'
+link: "https://docs.microsoft.com/en-us/style-guide"
 level: suggestion
 ignorecase: true
 tokens:

--- a/docs/v2/guides/operations/authentication/login-with-github.mdx
+++ b/docs/v2/guides/operations/authentication/login-with-github.mdx
@@ -78,11 +78,13 @@ The last bit of configuration is the session details. In order for the browser t
 ```bash
 docker run -it --rm \
   -p 8080:8080 \
-  -v "$(pwd)/config.yml:/config.yml" \
-  flipt/flipt:v2 ./flipt server --config /config.yml
+  -p 9000:9000 \
+  -v $HOME/flipt:/var/opt/flipt \
+  -v "$(pwd)/config.yml:/etc/flipt/config/default.yml" \
+  docker.flipt.io/flipt/flipt:v2
 ```
 
-This will mount the `config.yml` as a volume in the container, and Flipt will use that configuration as it's provided as a command line flag option.
+This will mount both the data directory for persistent storage and the `config.yml` configuration file into the container at the standard location.
 
 ### 3. Navigate to the Flipt UI
 

--- a/docs/v2/installation.mdx
+++ b/docs/v2/installation.mdx
@@ -117,6 +117,7 @@ docker run -d \
 ```
 
 In this configuration:
+
 - `$HOME/flipt:/var/opt/flipt` mounts the host directory for persistent data storage
 - `$HOME/flipt/config.yaml:/etc/flipt/config/default.yml` mounts your custom configuration file
 

--- a/docs/v2/installation.mdx
+++ b/docs/v2/installation.mdx
@@ -103,15 +103,31 @@ application.
 
 ### Configuration
 
-A default configuration file is included within the image. To supply a custom configuration, update the `docker run` command to mount your local configuration into the container:
+A default configuration file is included within the image. To supply a custom configuration, update the `docker run` command to mount your local configuration into the container.
+
+The example below shows how to configure Flipt v2 with both persistent storage and a custom configuration file:
 
 ```console
 docker run -d \
     -p 8080:8080 \
     -p 9000:9000 \
     -v $HOME/flipt:/var/opt/flipt \
-    -v $HOME/flipt/config.yaml:/etc/flipt/config.yaml \
+    -v $HOME/flipt/config.yaml:/etc/flipt/config/default.yml \
     docker.flipt.io/flipt/flipt:v2
+```
+
+In this configuration:
+- `$HOME/flipt:/var/opt/flipt` mounts the host directory for persistent data storage
+- `$HOME/flipt/config.yaml:/etc/flipt/config/default.yml` mounts your custom configuration file
+
+Your `config.yaml` should specify the full path for storage:
+
+```yaml
+storage:
+  default:
+    backend:
+      type: local
+      path: /var/opt/flipt
 ```
 
 ## Homebrew


### PR DESCRIPTION
Fixes incorrect Docker configuration paths in v2 documentation and adds comprehensive persistent storage examples.

## Summary
- Corrected config mount path from `/etc/flipt/config.yaml` to `/etc/flipt/config/default.yml`
- Enhanced installation docs with complete persistent storage and custom config example
- Updated GitHub authentication guide to use correct mount paths
- Added proper storage configuration YAML example

## Files Changed
- `docs/v2/installation.mdx` - Main Docker installation documentation
- `docs/v2/guides/operations/authentication/login-with-github.mdx` - GitHub auth guide

The documentation now consistently shows the correct Docker configuration pattern for Flipt v2 with persistent storage.

Fixes #371

🤖 Generated with [Claude Code](https://claude.ai/code)