### PR TITLE
docs: fix broken GitOps link in v1 documentation

### DIFF
--- a/docs/v1/usecases/gitops.mdx
+++ b/docs/v1/usecases/gitops.mdx
@@ -23,7 +23,7 @@ Flipt's declarative storage backends allow it to run without a database at all. 
 
 Our git support enables you to evaluate feature flags across different branches and tags. This allows developers to test feature flags in a staging environment before merging them into production, or leverage preview environments to test feature flags in isolation.
 
-Read our [Get Going with GitOps](https://www.flipt.io/docs/guides/user/get-going-with-gitops) guide to learn how to get started with GitOps and Flipt.
+Read our [Get Going with GitOps](https://docs.flipt.io/v1/guides/user/get-going-with-gitops#get-going-with-gitops) guide to learn how to get started with GitOps and Flipt.
 
 ## CI/CD Integration
 


### PR DESCRIPTION
Fixes the 'Get Going with GitOps' link that was redirecting to a 404 page.

Updated URL from www.flipt.io/docs/... to docs.flipt.io/v1/...

Resolves #380

Generated with [Claude Code](https://claude.ai/code)