### PR TITLE
docs: add v2.6.0 features - GitHub App auth, OIDC algorithms, and UserInfo claims

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,22 @@ Changes are automatically deployed to production when pushed to the main branch.
 
 ## Quality Assurance
 
+### Visual Verification
+
+After making any documentation changes, you MUST use the Playwright MCP browser tools to verify the changes render correctly in the local dev server (`mint dev`, typically running on port 3000):
+
+1. Get browser context with `tabs_context_mcp` (create tab group if needed)
+2. Create a new tab with `tabs_create_mcp`
+3. Navigate to each changed page at `http://localhost:3000/...`
+4. Scroll to each modified section (use `find` + `scroll_to` to locate headings)
+5. Take screenshots to verify:
+   - Content renders correctly (no broken markdown, missing sections, or layout issues)
+   - Code blocks display with proper syntax highlighting
+   - Tables are well-formatted with correct columns and alignment
+   - Callout components (`<Note>`, `<Warning>`, `<Tip>`) render properly
+   - "On this page" navigation includes new sections
+   - Links are functional
+
 ### Automated Checks
 
 - ESLint with MDX support for linting

--- a/docs/v2/configuration/authentication.mdx
+++ b/docs/v2/configuration/authentication.mdx
@@ -291,6 +291,53 @@ Since OIDC has the ability to retrieve email addresses, Flipt also provides a co
 
 You can see an example of that above in the [sample configuration](#method-oidc).
 
+#### Algorithms
+
+By default, Flipt expects OIDC ID tokens to be signed with the `RS256` algorithm. Some identity providers sign tokens with other algorithms (for example, `ES256` or `PS256`). You can configure the accepted signing algorithms per provider using the `algorithms` field.
+
+Supported algorithms: `RS256`, `RS384`, `RS512`, `ES256`, `ES384`, `ES512`, `PS256`, `PS384`, `PS512`.
+
+```yaml config.yaml
+authentication:
+  required: true
+  methods:
+    oidc:
+      enabled: true
+      providers:
+        some_provider:
+          issuer_url: "https://some.oidc.issuer.com"
+          client_id: "some_client_identifier"
+          client_secret: "some_client_secret_credential"
+          redirect_address: "https://your.flipt.instance.url.com"
+          algorithms:
+            - ES256
+```
+
+If not specified, the default is `["RS256"]`.
+
+#### UserInfo Claims
+
+Some OIDC providers keep ID token claims minimal and require calling the UserInfo endpoint to obtain additional attributes such as email, display name, or group membership. This is especially common for providers that omit or truncate group claims in the ID token.
+
+You can enable fetching additional claims from the provider's UserInfo endpoint by setting `fetch_extra_user_info` to `true`. When enabled, Flipt calls the UserInfo endpoint during the login callback and merges the returned claims into the session.
+
+```yaml config.yaml
+authentication:
+  required: true
+  methods:
+    oidc:
+      enabled: true
+      providers:
+        some_provider:
+          issuer_url: "https://some.oidc.issuer.com"
+          client_id: "some_client_identifier"
+          client_secret: "some_client_secret_credential"
+          redirect_address: "https://your.flipt.instance.url.com"
+          fetch_extra_user_info: true
+```
+
+If not specified, the default is `false`.
+
 #### PKCE
 
 A good amount of OIDC providers support the PKCE (Proof Key for Code Exchange) flow and the implicit OAuth flow. Flipt allows for a configuration to enable PKCE for all the legs of the OIDC authentication flow.

--- a/docs/v2/configuration/overview.mdx
+++ b/docs/v2/configuration/overview.mdx
@@ -341,16 +341,18 @@ Authentication configuration controls how users and systems authenticate with Fl
 
 #### Authentication Methods: OIDC
 
-| Property                                                          | Description                                                      | Default | Since  |
-| ----------------------------------------------------------------- | ---------------------------------------------------------------- | ------- | ------ |
-| authentication.methods.oidc.enabled                               | Enable OIDC authentication                                       | false   | v2.0.0 |
-| authentication.methods.oidc.providers.[provider].issuer_url       | Provider specific OIDC issuer URL (see your providers docs)      |         | v2.0.0 |
-| authentication.methods.oidc.providers.[provider].client_id        | Provider specific OIDC client ID (see your providers docs)       |         | v2.0.0 |
-| authentication.methods.oidc.providers.[provider].client_secret    | Provider specific OIDC client secret (see your providers docs)   |         | v2.0.0 |
-| authentication.methods.oidc.providers.[provider].redirect_address | Public URL on which this Flipt instance is reachable             |         | v2.0.0 |
-| authentication.methods.oidc.providers.[provider].scopes           | Scopes to request from the provider                              |         | v2.0.0 |
-| authentication.methods.oidc.providers.[provider].use_pkce         | Option for enabling PKCE for OIDC authentication flow            | false   | v2.0.0 |
-| authentication.methods.oidc.email_matches                         | List of email addresses (regex) of users allowed to authenticate |         | v2.0.0 |
+| Property                                                               | Description                                                      | Default   | Since  |
+| ---------------------------------------------------------------------- | ---------------------------------------------------------------- | --------- | ------ |
+| authentication.methods.oidc.enabled                                    | Enable OIDC authentication                                       | false     | v2.0.0 |
+| authentication.methods.oidc.providers.[provider].issuer_url            | Provider specific OIDC issuer URL (see your providers docs)      |           | v2.0.0 |
+| authentication.methods.oidc.providers.[provider].client_id             | Provider specific OIDC client ID (see your providers docs)       |           | v2.0.0 |
+| authentication.methods.oidc.providers.[provider].client_secret         | Provider specific OIDC client secret (see your providers docs)   |           | v2.0.0 |
+| authentication.methods.oidc.providers.[provider].redirect_address      | Public URL on which this Flipt instance is reachable             |           | v2.0.0 |
+| authentication.methods.oidc.providers.[provider].scopes                | Scopes to request from the provider                              |           | v2.0.0 |
+| authentication.methods.oidc.providers.[provider].use_pkce              | Option for enabling PKCE for OIDC authentication flow            | false     | v2.0.0 |
+| authentication.methods.oidc.providers.[provider].algorithms            | List of accepted ID token signing algorithms                     | ["RS256"] | v2.6.0 |
+| authentication.methods.oidc.providers.[provider].fetch_extra_user_info | Fetch additional claims from the provider's UserInfo endpoint    | false     | v2.6.0 |
+| authentication.methods.oidc.email_matches                              | List of email addresses (regex) of users allowed to authenticate |           | v2.0.0 |
 
 #### Authentication Methods: GitHub
 
@@ -407,17 +409,42 @@ Authorization configuration enforces fine-grained access control policies to res
 
 Credentials configuration manages authentication details for accessing remote Git repositories and SCM providers.
 
-| Property                                      | Description                                                        | Default | Since  |
-| --------------------------------------------- | ------------------------------------------------------------------ | ------- | ------ |
-| credentials.[id].type                         | The type of credentials to use (options: basic, ssh, access_token) | basic   | v2.0.0 |
-| credentials.[id].basic.username               | The username to use for basic authentication                       |         | v2.0.0 |
-| credentials.[id].basic.password               | The password to use for basic authentication                       |         | v2.0.0 |
-| credentials.[id].ssh.user                     | The username to use for SSH authentication                         | git     | v2.0.0 |
-| credentials.[id].ssh.password                 | Password used to generate the SSH key pair                         |         | v2.0.0 |
-| credentials.[id].ssh.private_key_path         | Path to private key on the filesystem                              |         | v2.0.0 |
-| credentials.[id].ssh.private_key_bytes        | (Alternative) Raw private key bytes                                |         | v2.0.0 |
-| credentials.[id].ssh.insecure_ignore_host_key | Skip verifying the known hosts key (avoid in production)           | false   | v2.0.0 |
-| credentials.[id].access_token                 | The token to use for authentication                                |         | v2.0.0 |
+| Property              | Description                                                                    | Default | Since  |
+| --------------------- | ------------------------------------------------------------------------------ | ------- | ------ |
+| credentials.[id].type | The type of credentials to use (options: basic, ssh, access_token, github_app) | basic   | v2.0.0 |
+
+#### Credentials: Basic
+
+| Property                        | Description                                  | Default | Since  |
+| ------------------------------- | -------------------------------------------- | ------- | ------ |
+| credentials.[id].basic.username | The username to use for basic authentication |         | v2.0.0 |
+| credentials.[id].basic.password | The password to use for basic authentication |         | v2.0.0 |
+
+#### Credentials: SSH
+
+| Property                                      | Description                                              | Default | Since  |
+| --------------------------------------------- | -------------------------------------------------------- | ------- | ------ |
+| credentials.[id].ssh.user                     | The username to use for SSH authentication               | git     | v2.0.0 |
+| credentials.[id].ssh.password                 | Password used to generate the SSH key pair               |         | v2.0.0 |
+| credentials.[id].ssh.private_key_path         | Path to private key on the filesystem                    |         | v2.0.0 |
+| credentials.[id].ssh.private_key_bytes        | (Alternative) Raw private key bytes                      |         | v2.0.0 |
+| credentials.[id].ssh.insecure_ignore_host_key | Skip verifying the known hosts key (avoid in production) | false   | v2.0.0 |
+
+#### Credentials: Access Token
+
+| Property                      | Description                         | Default | Since  |
+| ----------------------------- | ----------------------------------- | ------- | ------ |
+| credentials.[id].access_token | The token to use for authentication |         | v2.0.0 |
+
+#### Credentials: GitHub App
+
+| Property                                      | Description                                          | Default | Since  |
+| --------------------------------------------- | ---------------------------------------------------- | ------- | ------ |
+| credentials.[id].github_app.client_id         | The GitHub App client ID                             |         | v2.6.0 |
+| credentials.[id].github_app.installation_id   | The GitHub App installation ID                       |         | v2.6.0 |
+| credentials.[id].github_app.private_key_path  | Path to the GitHub App private key on the filesystem |         | v2.6.0 |
+| credentials.[id].github_app.private_key_bytes | (Alternative) Raw GitHub App private key bytes       |         | v2.6.0 |
+| credentials.[id].github_app.api_url           | Custom GitHub API URL (for GitHub Enterprise Server) |         | v2.6.0 |
 
 ### Secrets
 

--- a/docs/v2/configuration/storage.mdx
+++ b/docs/v2/configuration/storage.mdx
@@ -143,6 +143,7 @@ Supported authentication schemes are:
 - `basic`
 - `ssh`
 - `access_token`
+- `github_app`
 
 Credentials are configured using the `credentials` configuration section and use identifiers to reference the credentials in the configuration.
 
@@ -216,4 +217,52 @@ credentials:
   github:
     type: access_token
     access_token: < github-access-token >
+```
+
+#### GitHub App
+
+GitHub App authentication provides a more secure alternative to personal access tokens (PATs) for authenticating with GitHub repositories. GitHub App tokens are short-lived, offer higher rate limits, and provide more granular permissions.
+
+To use this credential type, you need to [create a GitHub App](https://docs.github.com/en/apps/creating-github-apps) and install it on your repository or organization.
+
+You can provide the private key either as a file path or as raw bytes inline:
+
+```yaml
+credentials:
+  github:
+    type: github_app
+    github_app:
+      client_id: < github-app-client-id >
+      installation_id: < github-app-installation-id >
+      private_key_path: /path/to/private-key.pem
+```
+
+Alternatively, you can pass the private key bytes inline:
+
+```yaml
+credentials:
+  github:
+    type: github_app
+    github_app:
+      client_id: < github-app-client-id >
+      installation_id: < github-app-installation-id >
+      private_key_bytes: < raw-private-key-bytes >
+```
+
+<Note>
+  You must provide either `private_key_path` or `private_key_bytes`, but not
+  both.
+</Note>
+
+For GitHub Enterprise Server, you can optionally specify a custom API URL:
+
+```yaml
+credentials:
+  github:
+    type: github_app
+    github_app:
+      client_id: < github-app-client-id >
+      installation_id: < github-app-installation-id >
+      private_key_path: /path/to/private-key.pem
+      api_url: "https://github.example.com/api/v3"
 ```


### PR DESCRIPTION
## Summary

- Document new GitHub App credential type for Git storage authentication (flipt-io/flipt#5327)
- Document new OIDC `algorithms` provider config for customizing accepted ID token signing algorithms (flipt-io/flipt#5362)
- Document new OIDC `fetch_extra_user_info` provider config for merging UserInfo endpoint claims into auth sessions (flipt-io/flipt#5364)
- Update configuration overview reference tables with all new properties (since v2.6.0)
- Break up monolithic credentials reference table into per-type subsections for readability
- Add visual verification instructions to AGENTS.md for browser-based QA using Playwright MCP tools