### PR TITLE
docs: add secret references for static token authentication

### DIFF
--- a/docs/v2/configuration/authentication.mdx
+++ b/docs/v2/configuration/authentication.mdx
@@ -196,6 +196,51 @@ authentication:
               some_key: "some_value"
 ```
 
+#### Using Secret References
+
+To avoid storing token values directly in your configuration file, you can use [secret references](/v2/configuration/overview#secret-references) with a configured [secret provider](/v2/configuration/secrets).
+
+Using the [file provider](/v2/configuration/secrets#file-provider):
+
+```yaml config.yaml
+authentication:
+  required: true
+  methods:
+    token:
+      enabled: true
+      storage:
+        tokens:
+          "ci_token":
+            credential: "${secret:file:ci-token}"
+            metadata:
+              name: "CI Pipeline Token"
+          "dev_token":
+            credential: "${secret:file:dev-token}"
+            metadata:
+              name: "Development Token"
+```
+
+Using the [HashiCorp Vault provider](/v2/configuration/secrets#hashicorp-vault-provider):
+
+```yaml config.yaml
+authentication:
+  required: true
+  methods:
+    token:
+      enabled: true
+      storage:
+        tokens:
+          "ci_token":
+            credential: "${secret:vault:flipt/tokens:ci-token}"
+            metadata:
+              name: "CI Pipeline Token"
+```
+
+<Tip>
+  See [Secrets](/v2/configuration/secrets) for details on configuring secret
+  providers.
+</Tip>
+
 ### OIDC
 
 <Note>The `OIDC` method is a `session compatible` authentication method.</Note>

--- a/docs/v2/configuration/authentication.mdx
+++ b/docs/v2/configuration/authentication.mdx
@@ -211,11 +211,11 @@ authentication:
       storage:
         tokens:
           "ci_token":
-            credential: "${secret:file:ci-token}"
+            credential: "${secret:file:ci-token}" # References /etc/flipt/secrets/ci-token
             metadata:
               name: "CI Pipeline Token"
           "dev_token":
-            credential: "${secret:file:dev-token}"
+            credential: "${secret:file:dev-token}" # References /etc/flipt/secrets/dev-token
             metadata:
               name: "Development Token"
 ```
@@ -231,9 +231,13 @@ authentication:
       storage:
         tokens:
           "ci_token":
-            credential: "${secret:vault:flipt/tokens:ci-token}"
+            credential: "${secret:vault:flipt/tokens:ci-token}" # References flipt/tokens secret, key: ci-token
             metadata:
               name: "CI Pipeline Token"
+          "dev_token":
+            credential: "${secret:vault:flipt/tokens:dev-token}" # References flipt/tokens secret, key: dev-token
+            metadata:
+              name: "Development Token"
 ```
 
 <Tip>

--- a/docs/v2/configuration/secrets.mdx
+++ b/docs/v2/configuration/secrets.mdx
@@ -173,6 +173,13 @@ authentication:
   session:
     csrf:
       key: ${secret:file:csrf-key} # References /etc/flipt/secrets/csrf-key
+  methods:
+    token:
+      enabled: true
+      storage:
+        tokens:
+          "ci_token":
+            credential: ${secret:file:ci-token} # References /etc/flipt/secrets/ci-token
 ```
 
 ### Vault Provider Examples
@@ -188,6 +195,12 @@ authentication:
         github:
           client_id: ${secret:vault:auth/github:client_id}
           client_secret: ${secret:vault:auth/github:client_secret}
+    token:
+      enabled: true
+      storage:
+        tokens:
+          "ci_token":
+            credential: ${secret:vault:flipt/tokens:ci-token}
 ```
 
 ### Combined with Environment Variables

--- a/docs/v2/configuration/secrets.mdx
+++ b/docs/v2/configuration/secrets.mdx
@@ -166,41 +166,43 @@ Secret references use the format `${secret:provider:key}` where:
 
 ```yaml
 server:
-  cert_file: ${secret:file:tls-cert} # References /etc/flipt/secrets/tls-cert
-  cert_key: ${secret:file:tls-key} # References /etc/flipt/secrets/tls-key
+  cert_file: "${secret:file:tls-cert}" # References /etc/flipt/secrets/tls-cert
+  cert_key: "${secret:file:tls-key}" # References /etc/flipt/secrets/tls-key
 
 authentication:
+  required: true
   session:
     csrf:
-      key: ${secret:file:csrf-key} # References /etc/flipt/secrets/csrf-key
+      key: "${secret:file:csrf-key}" # References /etc/flipt/secrets/csrf-key
   methods:
     token:
       enabled: true
       storage:
         tokens:
           "ci_token":
-            credential: ${secret:file:ci-token} # References /etc/flipt/secrets/ci-token
+            credential: "${secret:file:ci-token}" # References /etc/flipt/secrets/ci-token
 ```
 
 ### Vault Provider Examples
 
 ```yaml
 authentication:
+  required: true
   methods:
     oidc:
       providers:
         google:
-          client_id: ${secret:vault:auth/oidc:client_id}
-          client_secret: ${secret:vault:auth/oidc:client_secret}
+          client_id: "${secret:vault:auth/oidc:client_id}"
+          client_secret: "${secret:vault:auth/oidc:client_secret}"
         github:
-          client_id: ${secret:vault:auth/github:client_id}
-          client_secret: ${secret:vault:auth/github:client_secret}
+          client_id: "${secret:vault:auth/github:client_id}"
+          client_secret: "${secret:vault:auth/github:client_secret}"
     token:
       enabled: true
       storage:
         tokens:
           "ci_token":
-            credential: ${secret:vault:flipt/tokens:ci-token}
+            credential: "${secret:vault:flipt/tokens:ci-token}"
 ```
 
 ### Combined with Environment Variables


### PR DESCRIPTION
Add documentation explaining how to use secret references to securely manage static authentication tokens in Flipt v2.

## Changes

- Updated static token auth docs with file and Vault secret reference examples
- Added cross-references between authentication, secrets, and secret references docs
- Extended secrets.mdx usage examples to include static token authentication

Closes #349

Generated with [Claude Code](https://claude.ai/code)