### PR TITLE
Update v2 Pro pricing

### DIFF
--- a/docs/v2/pro.mdx
+++ b/docs/v2/pro.mdx
@@ -96,7 +96,7 @@ Get the help you need when you need it:
 
 ### Monthly Subscription
 
-- **Price**: \$100/month
+- **Price**: \$200/month
 - **Trial**: 14-day free trial included
 - **Validation**: Requires internet connectivity
 - **Billing**: Monthly via Stripe
@@ -104,7 +104,7 @@ Get the help you need when you need it:
 
 ### Annual License
 
-- **Price**: \$1,000/year (**save $200**)
+- **Price**: \$2,000/year (**save $400**)
 - **Offline Support**: Works in air-gapped environments
 - **Validation**: Local license validation
 - **Billing**: Annual via Stripe


### PR DESCRIPTION
## Summary

- Double monthly Pro subscription price from $100/month to $200/month
- Double annual Pro license price from $1,000/year to $2,000/year
- Update annual savings amount from $200 to $400