### PR TITLE
docs: add FlagLint migration workflow

### DIFF
--- a/docs/v1/guides/migration/launchdarkly/openfeature.mdx
+++ b/docs/v1/guides/migration/launchdarkly/openfeature.mdx
@@ -53,6 +53,23 @@ Finally, search for references of the LaunchDarkly client instance: in our examp
 If you're using VS Code, this is what you'd see after calling _Go to References_ on `ldClient`:
 ![Searching for usages of LaunchDarkly client instance in VS Code](/v1/images/guides/migration/launchdarkly/usages_vscode.png)
 
+### Optional: Use FlagLint
+
+For larger JavaScript and TypeScript codebases, you can use [FlagLint](https://flaglint.dev/) to analyze supported direct LaunchDarkly Node.js SDK usages with AST analysis:
+
+```bash
+# List detected call sites
+npx flaglint scan ./src
+
+# Summarize migration risk and readiness
+npx flaglint audit ./src
+
+# Preview safe OpenFeature call-site rewrites without changing files
+npx flaglint migrate ./src --dry-run
+```
+
+The migration preview skips usages that FlagLint cannot safely rewrite. FlagLint analyzes application call sites but does not migrate flag definitions, targeting rules, environment configuration, backend state, or provider setup.
+
 ## Installing and Importing OpenFeature Packages
 
 When you're using LaunchDarkly's own SDK, your application declares this package as a dependency:


### PR DESCRIPTION
## Summary

Adds FlagLint as an optional AST-based workflow in the existing LaunchDarkly-to-OpenFeature migration guide.

The existing manual IDE and text-search workflow remains unchanged. The new section shows how to:

* inventory supported LaunchDarkly call sites with `scan`
* summarize migration risk and readiness with `audit`
* preview safe OpenFeature call-site rewrites with `migrate --dry-run`

## Scope

This change documents application source-code analysis and call-site migration only.

FlagLint does not migrate:

* flag definitions
* targeting rules
* environments
* backend state
* provider configuration

## Verification

* Verified the documented commands against published `flaglint@0.8.0`
* Ran Vale on the modified MDX file
* Previewed the page locally with Mintlify
* Confirmed `migrate --dry-run` does not modify source files

I scoped this change to the existing v1 LaunchDarkly-to-OpenFeature migration guide. I'm happy to add equivalent guidance under v2 if the maintainers prefer a corresponding migration page there.

closes #408.