### PR TITLE
docs: document configurable templates

### DIFF
--- a/docs/v2/configuration/overview.mdx
+++ b/docs/v2/configuration/overview.mdx
@@ -626,6 +626,34 @@ Analytics configuration enables collection and export of feature flag evaluation
 
 ## Additional Settings
 
+### Templates
+
+Templates configuration customizes the generated commit messages and merge proposal content that Flipt creates for Git-backed workflows. Template values use Go [`text/template`](https://pkg.go.dev/text/template) syntax.
+
+| Property                 | Description                                    | Default | Since  |
+| ------------------------ | ---------------------------------------------- | ------- | ------ |
+| templates.commit_message | Commit message template for UI-created changes |         | v2.5.0 |
+| templates.proposal_title | Merge proposal title template                  |         | v2.5.0 |
+| templates.proposal_body  | Merge proposal body template                   |         | v2.5.0 |
+
+```yaml config.yaml
+templates:
+  commit_message: "{{ (index .Changes 0) }} [skip ci]"
+  proposal_title: "Flipt: Update {{.Base.Ref}} from {{.Branch.Ref}}"
+  proposal_body: |
+    This proposal updates Flipt resources.
+
+    Source branch: {{.Branch.Ref}}
+    Target branch: {{.Base.Ref}}
+```
+
+Server-wide templates override Flipt's built-in defaults. Repository-level templates in `flipt.yaml` or `flipt.yml` override server-wide templates for that repository.
+
+<Note>
+  Flipt validates configured templates when it loads the configuration. Invalid
+  server-wide templates prevent the configuration from loading.
+</Note>
+
 ### License
 
 License configuration enables Pro features by providing a valid license key.

--- a/docs/v2/guides/user/environments/merge-proposals.mdx
+++ b/docs/v2/guides/user/environments/merge-proposals.mdx
@@ -56,6 +56,49 @@ Refresh the page and click the branch info label again to see the merge proposal
 
 Click the `View open merge proposal` button to view the merge proposal in the SCM provider.
 
+### Customizing Generated Titles and Descriptions
+
+Flipt generates merge proposal titles and descriptions from Go [`text/template`](https://pkg.go.dev/text/template) templates. You can configure server-wide defaults in your Flipt configuration:
+
+```yaml config.yaml
+templates:
+  proposal_title: "Flipt: Update {{.Base.Ref}} from {{.Branch.Ref}}"
+  proposal_body: |
+    This proposal updates Flipt resources.
+
+    Source branch: {{.Branch.Ref}}
+    Target branch: {{.Base.Ref}}
+```
+
+The template context includes:
+
+| Field               | Description                                  |
+| ------------------- | -------------------------------------------- |
+| `.Base`             | The target environment configuration         |
+| `.Branch`           | The source branch environment configuration  |
+| `.Base.Ref`         | The target Git reference, such as `main`     |
+| `.Branch.Ref`       | The source Git reference for the branch      |
+| `.Base.Directory`   | The target directory, when one is configured |
+| `.Branch.Directory` | The branch directory, when one is configured |
+
+Repository-level templates in `flipt.yaml` or `flipt.yml` override the server-wide templates for that repository:
+
+```yaml flipt.yaml
+version: "2.0"
+templates:
+  proposal_title: "Flags: {{.Branch.Ref}} into {{.Base.Ref}}"
+  proposal_body: |
+    Review changes from {{.Branch.Ref}} before merging into {{.Base.Ref}}.
+```
+
+<Note>
+  These templates configure the generated defaults. If a merge proposal request
+  provides a title or description, Flipt uses the provided value instead of the
+  template. The Flipt UI can provide a one-off description, but it does not yet
+  let you edit the configured template text or override the generated title
+  directly.
+</Note>
+
 ### Review and Merge a Merge Proposal
 
 Reviewing and merging a merge proposal is the same as reviewing and merging a code pull request in your SCM provider.


### PR DESCRIPTION
## Summary
- Document server-wide configurable commit and merge proposal templates
- Add merge proposal examples and template context details
- Clarify repository-level templates override server-wide defaults and the current UI override limitation

## Verification
- Verified implementation against flipt-io/flipt branch v2
- `npm run lint -- --quiet v2/configuration/overview.mdx v2/guides/user/environments/merge-proposals.mdx`
- `npx prettier --write v2/configuration/overview.mdx v2/guides/user/environments/merge-proposals.mdx`
- `git diff --check`
- Fresh reviewer pass

Closes #411
