### PR TITLE
docs: add MCP server docs for v2

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -171,7 +171,8 @@
                 "icon": "hammer",
                 "tag": "NEW",
                 "pages": [
-                  "v2/tooling/github-actions"
+                  "v2/tooling/github-actions",
+                  "v2/tooling/model-context-protocol"
                 ]
               }
             ]

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -534,7 +534,7 @@
     "dark": "/logo/dark-logo.svg"
   },
   "banner": {
-    "content": "🎉 **New in Flipt Pro:** Integrated secrets management with HashiCorp Vault, AWS Secrets Manager, GCP Secret Manager, and Azure Key Vault. [Learn more](https://docs.flipt.io/v2/pro).",
+    "content": "🎉 **New:** MCP server for Flipt v2. Let AI assistants manage and evaluate your feature flags. [Learn more](https://docs.flipt.io/v2/tooling/model-context-protocol).",
     "dismissible": true
   },
   "api": {

--- a/docs/v1/tooling/model-context-protocol.mdx
+++ b/docs/v1/tooling/model-context-protocol.mdx
@@ -7,7 +7,12 @@ description: Use Flipt's MCP server to enable AI assistants to interact with you
 
 The [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) is an open protocol that standardizes how applications provide context to Large Language Models (LLMs). Think of MCP like a USB-C port for AI applications - it provides a standardized way to connect AI models to different data sources and tools.
 
-[Flipt's MCP server](https://github.com/flipt-io/mcp-server-flipt) allows AI assistants and LLMs to directly interact with your feature flags, segments, and evaluations through a standardized interface. This enables powerful AI-driven workflows and integrations with tools that support the MCP protocol.
+[Flipt's MCP server](https://github.com/flipt-io/mcp-server-flipt/tree/main/packages/mcp-server-flipt) allows AI assistants and LLMs to directly interact with your feature flags, segments, and evaluations through a standardized interface. This enables powerful AI-driven workflows and integrations with tools that support the MCP protocol.
+
+<Note>
+  Using Flipt v2? See the [v2 MCP server
+  documentation](/v2/tooling/model-context-protocol) instead.
+</Note>
 
 ![MCP Server](/v1/images/tooling/mcp.png)
 
@@ -40,7 +45,7 @@ The Flipt MCP server can be integrated into broader AI agent workflows to:
 
 ## Getting Started
 
-Check out the [Flipt MCP server repository](https://github.com/flipt-io/mcp-server-flipt) for the most up to date information on how to use the MCP server.
+Check out the [Flipt MCP server repository](https://github.com/flipt-io/mcp-server-flipt/tree/main/packages/mcp-server-flipt) for the most up to date information on how to use the MCP server.
 
 ### Cursor
 
@@ -67,7 +72,7 @@ The server can be configured using environment variables:
 
 ```bash
 # The URL of your Flipt instance
-FLIPT_API_URL=http://localhost:8080
+FLIPT_URL=http://localhost:8080
 
 # Optional API key for authentication
 FLIPT_API_KEY=<your-api-key>

--- a/docs/v2/tooling/model-context-protocol.mdx
+++ b/docs/v2/tooling/model-context-protocol.mdx
@@ -1,0 +1,114 @@
+---
+title: Model Context Protocol (MCP)
+description: Use Flipt's MCP server to enable AI assistants to interact with your feature flags
+---
+
+## Overview
+
+The [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) is an open protocol that standardizes how applications provide context to Large Language Models (LLMs). Think of MCP like a USB-C port for AI applications - it provides a standardized way to connect AI models to different data sources and tools.
+
+[Flipt's v2 MCP server](https://github.com/flipt-io/mcp-server-flipt/tree/main/packages/mcp-server-flipt-v2) allows AI assistants and LLMs to directly interact with your environments, feature flags, segments, and evaluations through a standardized interface. This enables powerful AI-driven workflows and integrations with tools that support the MCP protocol.
+
+<Note>
+  Using Flipt v1? See the [v1 MCP server
+  documentation](/v1/tooling/model-context-protocol) instead.
+</Note>
+
+## Use Cases
+
+### AI-Enabled IDEs
+
+When using AI-enabled IDEs like Cursor that support MCP, your AI assistant can:
+
+- Check feature flag states while reviewing code
+- Help toggle features on/off during development
+- Assist in creating and managing feature flags
+- Evaluate flags for specific users/entities
+- Create [branch environments](/v2/concepts#branches) to test flag changes safely and propose them back via your SCM
+- Help debug feature flag logic and rules
+
+For example, you could ask your AI assistant:
+
+- "What's the current state of the 'dark-mode' flag?"
+- "Enable the 'beta-features' flag for all users in the 'internal' segment"
+- "Create a branch of the production environment and add a flag for our upcoming notification system"
+
+### AI Agents and Workflows
+
+The Flipt MCP server can be integrated into broader AI agent workflows to:
+
+- Automate feature flag management based on system metrics
+- Coordinate feature rollouts across multiple services
+- Propose flag changes as pull requests through branch environments
+- Manage complex feature flag rules and segments
+
+## Getting Started
+
+Check out the [Flipt MCP server repository](https://github.com/flipt-io/mcp-server-flipt/tree/main/packages/mcp-server-flipt-v2) for the most up to date information on how to use the MCP server.
+
+### Cursor
+
+To use the Flipt MCP server with Cursor, you need to configure Cursor to use the MCP server.
+
+The Cursor docs have a [guide on how to configure Cursor](https://docs.cursor.com/context/model-context-protocol#configuring-mcp-servers) to use a MCP server.
+
+For Flipt v2, you can use the following configuration:
+
+```json
+{
+  "mcpServers": {
+    "flipt": {
+      "command": "npx",
+      "args": ["-y", "@flipt-io/mcp-server-flipt-v2"]
+    }
+  }
+}
+```
+
+### Docker
+
+You can also run the server in a Docker container:
+
+```bash
+docker run -d --name mcp-server-flipt-v2 ghcr.io/flipt-io/mcp-server-flipt-v2:latest
+```
+
+### Configuration
+
+The server can be configured using environment variables:
+
+```bash
+# The URL of your Flipt instance
+FLIPT_URL=http://localhost:8080
+
+# Optional API key for authentication
+FLIPT_API_KEY=<your-api-key>
+
+# The environment used when a tool call doesn't specify one
+FLIPT_ENVIRONMENT=default
+```
+
+You can also set these in a `.env` file in the directory where you run the server.
+
+## Available Tools
+
+Every tool that operates inside an environment accepts an optional `environmentKey`, falling back to the `FLIPT_ENVIRONMENT` environment variable.
+
+| Group         | Tools                                                                                                           |
+| ------------- | --------------------------------------------------------------------------------------------------------------- |
+| Environments  | `list_environments`, `list_branches`, `create_branch`, `delete_branch`, `propose_branch`, `list_branch_changes` |
+| Namespaces    | `list_namespaces`, `get_namespace`, `create_namespace`, `update_namespace`, `delete_namespace`                  |
+| Flags         | `list_flags`, `get_flag`, `create_flag`, `update_flag`, `delete_flag`, `toggle_flag`                            |
+| Variants      | `create_variant`, `update_variant`, `delete_variant`                                                            |
+| Rules         | `create_rule`, `delete_rule`                                                                                    |
+| Distributions | `create_distribution`, `delete_distribution`                                                                    |
+| Rollouts      | `create_rollout`, `delete_rollout`                                                                              |
+| Segments      | `list_segments`, `get_segment`, `create_segment`, `update_segment`, `delete_segment`                            |
+| Constraints   | `create_constraint`, `delete_constraint`                                                                        |
+| Evaluation    | `evaluate_boolean_flag`, `evaluate_variant_flag`, `evaluate_batch`                                              |
+
+### Notes on the v2 Data Model
+
+In Flipt v2, variants, rules, rollouts, distributions, and constraints live inside their parent flag or segment document rather than behind their own API endpoints. The corresponding tools read the parent document, apply the change, and write it back with the revision from the read, so a concurrent modification results in a conflict error instead of a lost update - fetch the resource again and retry.
+
+Rules, rollouts, and constraints have no IDs in v2; delete them by their index as shown by `get_flag` / `get_segment`. Variants and distributions are addressed by key.


### PR DESCRIPTION
## Summary

- Adds a new v2 docs page for the [Flipt v2 MCP server](https://github.com/flipt-io/mcp-server-flipt/tree/main/packages/mcp-server-flipt-v2) (`@flipt-io/mcp-server-flipt-v2`) under **Tooling**, covering:
  - Cursor and Docker setup
  - Configuration via `FLIPT_URL`, `FLIPT_API_KEY`, and `FLIPT_ENVIRONMENT`
  - Full tool list by group (environments, namespaces, flags, segments, evaluation, etc.)
  - Notes on the v2 data model (revision-based writes, index/key-based deletes)
- Updates the v1 MCP page to link to the [v1 package directory](https://github.com/flipt-io/mcp-server-flipt/tree/main/packages/mcp-server-flipt), cross-link the new v2 page, and fix the config example (`FLIPT_API_URL` → `FLIPT_URL`)
- Updates the site banner to announce the v2 MCP server

Screenshot for the v2 page to be added in a follow-up.

## Verification

- Prettier, ESLint, and Vale all pass
- Both pages and the banner verified rendering locally with `mint dev`