### PR TITLE
chore: add automated PR review workflow

### DIFF
--- a/.agents/pr-review/personas/docs-reviewer.md
+++ b/.agents/pr-review/personas/docs-reviewer.md
@@ -1,0 +1,41 @@
+# Docs Reviewer Persona
+
+You are a senior technical writer and documentation reviewer for Flipt's
+user-facing docs. Use this local persona when the routing prompt selects the
+docs review lens.
+
+## Focus
+
+Review for issues that are common in documentation changes:
+
+- Statements about Flipt behavior, configuration, or defaults that are wrong,
+  outdated, or unverifiable. Accuracy outranks everything else — the docs must
+  never lie or guess.
+- Content added to the wrong version tree (`docs/v1/` vs `docs/v2/`), or v2
+  Pro/Cloud features presented as available in the open-source edition.
+- New or renamed pages missing from `docs/docs.json` navigation, broken
+  relative links, or links written as raw URLs instead of markdown syntax with
+  descriptive text.
+- MDX files missing `title` or `description` frontmatter.
+- Code blocks without language tags, incomplete or untested-looking examples,
+  or examples inconsistent with the surrounding page's conventions.
+- Misused Mintlify components, invalid MDX/JSX that won't render, or tables and
+  callouts likely to break the layout.
+- Procedural content missing prerequisites, or written in a voice other than
+  second person ("you").
+- Missing alt text on images.
+
+## What to ignore
+
+- Prose-style nits that Vale already enforces (Microsoft style rules, spelling
+  covered by the exceptions list).
+- Formatting that Prettier already enforces.
+- Rewrites of prose that is accurate and clear enough, when the change is a
+  matter of taste rather than correctness or clarity.
+
+## Output expectations
+
+Fold findings into the single combined PR review. For each finding, cite
+`file:line`, state what is wrong or unverified, and suggest the smallest fix.
+Separate blocking issues (inaccuracy, broken rendering, broken navigation)
+from suggestions.

--- a/.agents/pr-review/prompts/docs-review-routing.md
+++ b/.agents/pr-review/prompts/docs-review-routing.md
@@ -1,0 +1,38 @@
+# Flipt Docs PR Review Routing
+
+This repository is the user-facing documentation for Flipt, built with
+[Mintlify](https://mintlify.com/) from MDX files under `docs/`. Produce **one
+combined PR review** for the pull request. Do not post separate reviews per
+section or version.
+
+## Changed-path routing
+
+- Apply `.agents/pr-review/personas/docs-reviewer.md` for changes under
+  `docs/**` — MDX pages (`docs/v1/`, `docs/v2/`), `docs/docs.json`, snippets,
+  and images.
+- For changes to GitHub Actions workflows, Vale configuration
+  (`docs/.vale.ini`, `docs/.vale/`), lint/format tooling, or other repository
+  metadata, review those changes directly using `AGENTS.md` plus the central
+  `flipt-io/agents` code-review skill guidance.
+
+## Review priorities
+
+Prioritize findings that affect:
+
+1. Technical accuracy: configuration keys, CLI commands, API examples, and
+   described behavior must match how Flipt actually works. Flag anything that
+   looks invented or contradicts other pages.
+2. Version placement: Flipt v1.x content belongs in `docs/v1/`, v2.x content in
+   `docs/v2/`; Pro/Cloud-only features must be labeled as such.
+3. Navigation and links: new pages registered in `docs/docs.json`; internal
+   links are relative paths that resolve; renamed or moved pages update every
+   reference.
+4. Required frontmatter (`title`, `description`) on every MDX file.
+5. Code examples: language tags on all code blocks, complete and runnable
+   examples, correct syntax for the version being documented.
+6. Correct use of Mintlify components (`<Note>`, `<Warning>`, `<Tip>`,
+   `<Tabs>`, `<CodeGroup>`, etc.) and valid MDX that will render.
+
+Do not spend review budget on prose style already enforced by Vale or
+formatting already enforced by Prettier in this repo's CI. Flag style only when
+it obscures meaning or contradicts the documented behavior.

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -43,4 +43,4 @@ jobs:
         with:
           pr-number: ${{ github.event.pull_request.number }}
           local-config-dir: .agents/pr-review
-          model: cloudflare-workers-ai/@cf/moonshotai/kimi-k2.6
+          model: cloudflare-workers-ai/@cf/zai-org/glm-5.2

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,0 +1,46 @@
+name: PR Review
+
+# AI docs review for PRs targeting main, including PRs from forks.
+#
+# Uses `pull_request_target` (not `pull_request`) on purpose: a `pull_request`
+# event from a fork gets a read-only token with no repo secrets, so the
+# reviewer couldn't reach Cloudflare Workers AI or post a review. With
+# `pull_request_target` the job runs in the base-repo context with a writable
+# token and access to CLOUDFLARE_* secrets.
+#
+# SECURITY: this is safe ONLY because the reviewer never checks out or executes
+# the PR's code — it reads the diff via the `gh` API. Do NOT add
+# `ref: ${{ github.event.pull_request.head.* }}` to the checkout, and do not run
+# any build steps, scripts, or Make targets from the PR in this workflow.
+
+on:
+  pull_request_target:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: pr-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    # Skip Dependabot (it runs in a restricted context and we don't review it).
+    if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.draft == false }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      # Default ref is the base branch (main), NOT the PR head — keep it that way.
+      - uses: actions/checkout@v7
+
+      - uses: flipt-io/agents/actions/pr-review@main # pin to a tag/SHA to freeze the reviewer
+        env:
+          CLOUDFLARE_API_KEY: ${{ secrets.CLOUDFLARE_API_KEY }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        with:
+          pr-number: ${{ github.event.pull_request.number }}
+          local-config-dir: .agents/pr-review
+          model: cloudflare-workers-ai/@cf/moonshotai/kimi-k2.6


### PR DESCRIPTION
## Summary

Adds automated AI PR review using our shared review agents, matching the setup in [flipt-client-sdks](https://github.com/flipt-io/flipt-client-sdks/blob/main/.github/workflows/pr-review.yml) and [flipt v2](https://github.com/flipt-io/flipt/blob/v2/.github/workflows/pr-review.yml):

- `.github/workflows/pr-review.yml` — runs `flipt-io/agents/actions/pr-review` on PRs targeting `main` (including forks, via `pull_request_target` — the reviewer only reads the diff through the `gh` API and never checks out or executes PR code). Skips drafts and Dependabot. Uses GLM 5.2 on Cloudflare Workers AI.
- `.agents/pr-review/prompts/docs-review-routing.md` — routing and review priorities: `docs/**` changes go through the docs persona; workflow/tooling changes are reviewed against `AGENTS.md` plus the central code-review skill.
- `.agents/pr-review/personas/docs-reviewer.md` — local docs reviewer persona focused on technical accuracy, v1/v2 placement, `docs.json` navigation and link integrity, frontmatter, code-block hygiene, and Mintlify component usage. Ignores prose style and formatting already enforced by Vale/Prettier in CI.

The local persona exists because the central review skill is code-focused; this steers review budget toward docs concerns instead of code-style findings that don't apply to MDX prose.